### PR TITLE
Scannet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ outputs/
 .env
 tests/
 .cache/
-
+runspace/inputs/scannet/
 # Apptainer
 Apptainer.def
 qbench_sandbox/

--- a/custom/helpers/download-scannet.py
+++ b/custom/helpers/download-scannet.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+# Downloads ScanNet public data release
+# Run with ./download-scannet.py (or python download-scannet.py on Windows)
+# -*- coding: utf-8 -*-
+import argparse
+import os
+import urllib.request 
+import tempfile
+
+import ssl 
+ssl._create_default_https_context = ssl._create_unverified_context
+
+BASE_URL = 'http://kaldir.vc.cit.tum.de/scannet/'
+TOS_URL = BASE_URL + 'ScanNet_TOS.pdf'
+FILETYPES = ['.aggregation.json', '.sens', '.txt', '_vh_clean.ply', '_vh_clean_2.0.010000.segs.json', '_vh_clean_2.ply', '_vh_clean.segs.json', '_vh_clean.aggregation.json', '_vh_clean_2.labels.ply', '_2d-instance.zip', '_2d-instance-filt.zip', '_2d-label.zip', '_2d-label-filt.zip']
+FILETYPES_TEST = ['.sens', '.txt', '_vh_clean.ply', '_vh_clean_2.ply']
+PREPROCESSED_FRAMES_FILE = ['scannet_frames_25k.zip', '5.6GB']
+TEST_FRAMES_FILE = ['scannet_frames_test.zip', '610MB']
+LABEL_MAP_FILES = ['scannetv2-labels.combined.tsv', 'scannet-labels.combined.tsv']
+DATA_EFFICIENT_FILES = ['limited-reconstruction-scenes.zip', 'limited-annotation-points.zip', 'limited-bboxes.zip', '1.7MB']
+GRIT_FILES = ['ScanNet-GRIT.zip']
+RELEASES = ['v2/scans', 'v1/scans']
+RELEASES_TASKS = ['v2/tasks', 'v1/tasks']
+RELEASES_NAMES = ['v2', 'v1']
+RELEASE = RELEASES[0]
+RELEASE_TASKS = RELEASES_TASKS[0]
+RELEASE_NAME = RELEASES_NAMES[0]
+LABEL_MAP_FILE = LABEL_MAP_FILES[0]
+RELEASE_SIZE = '1.2TB'
+V1_IDX = 1
+
+
+def get_release_scans(release_file):
+    scan_lines = urllib.request.urlopen(release_file)
+    scans = []
+    for scan_line in scan_lines:
+        scan_id = scan_line.decode('utf8').rstrip('\n')
+        scans.append(scan_id)
+    return scans
+
+
+def download_release(release_scans, out_dir, file_types, use_v1_sens, skip_existing):
+    if len(release_scans) == 0:
+        return
+    print('Downloading ScanNet ' + RELEASE_NAME + ' release to ' + out_dir + '...')
+    for scan_id in release_scans:
+        scan_out_dir = os.path.join(out_dir, scan_id)
+        download_scan(scan_id, scan_out_dir, file_types, use_v1_sens, skip_existing)
+    print('Downloaded ScanNet ' + RELEASE_NAME + ' release.')
+
+
+def download_file(url, out_file):
+    out_dir = os.path.dirname(out_file)
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
+    if not os.path.isfile(out_file):
+        print('\t' + url + ' > ' + out_file)
+        fh, out_file_tmp = tempfile.mkstemp(dir=out_dir)
+        f = os.fdopen(fh, 'w')
+        f.close()
+        urllib.request.urlretrieve(url, out_file_tmp)
+        os.rename(out_file_tmp, out_file)
+    else:
+        print('WARNING: skipping download of existing file ' + out_file)
+
+def download_scan(scan_id, out_dir, file_types, use_v1_sens, skip_existing=False):
+    print('Downloading ScanNet ' + RELEASE_NAME + ' scan ' + scan_id + ' ...')
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
+    for ft in file_types:
+        v1_sens = use_v1_sens and ft == '.sens'
+        url = BASE_URL + RELEASE + '/' + scan_id + '/' + scan_id + ft if not v1_sens else BASE_URL + RELEASES[V1_IDX] + '/' + scan_id + '/' + scan_id + ft
+        out_file = out_dir + '/' + scan_id + ft
+        if skip_existing and os.path.isfile(out_file):
+            continue
+        download_file(url, out_file)
+    print('Downloaded scan ' + scan_id)
+
+
+def download_task_data(out_dir):
+    print('Downloading ScanNet v1 task data...')
+    files = [
+        LABEL_MAP_FILES[V1_IDX], 'obj_classification/data.zip',
+        'obj_classification/trained_models.zip', 'voxel_labeling/data.zip',
+        'voxel_labeling/trained_models.zip'
+    ]
+    for file in files:
+        url = BASE_URL + RELEASES_TASKS[V1_IDX] + '/' + file
+        localpath = os.path.join(out_dir, file)
+        localdir = os.path.dirname(localpath)
+        if not os.path.isdir(localdir):
+          os.makedirs(localdir)
+        download_file(url, localpath)
+    print('Downloaded task data.')
+
+def download_tfrecords(in_dir, out_dir):
+    print('Downloading tf records (302 GB)...')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    split_to_num_shards = {'train': 100, 'val': 25, 'test': 10}
+
+    for folder_name in ['hires_tfrecords', 'lores_tfrecords']:
+        folder_dir = '%s/%s' % (in_dir, folder_name)
+        save_dir = '%s/%s' % (out_dir, folder_name)
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+        for split, num_shards in split_to_num_shards.items():
+            for i in range(num_shards):
+                file_name = '%s-%05d-of-%05d.tfrecords' % (split, i, num_shards)
+                url = '%s/%s' % (folder_dir, file_name)
+                localpath = '%s/%s/%s' % (out_dir, folder_name, file_name)
+                download_file(url, localpath)
+
+def download_label_map(out_dir):
+    print('Downloading ScanNet ' + RELEASE_NAME + ' label mapping file...')
+    files = [ LABEL_MAP_FILE ]
+    for file in files:
+        url = BASE_URL + RELEASE_TASKS + '/' + file
+        localpath = os.path.join(out_dir, file)
+        localdir = os.path.dirname(localpath)
+        if not os.path.isdir(localdir):
+          os.makedirs(localdir)
+        download_file(url, localpath)
+    print('Downloaded ScanNet ' + RELEASE_NAME + ' label mapping file.')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Downloads ScanNet public data release.')
+    parser.add_argument('-o', '--out_dir', required=True, help='directory in which to download')
+    parser.add_argument('--task_data', action='store_true', help='download task data (v1)')
+    parser.add_argument('--label_map', action='store_true', help='download label map file')
+    parser.add_argument('--v1', action='store_true', help='download ScanNet v1 instead of v2')
+    parser.add_argument('--id', help='specific scan id to download')
+    parser.add_argument('--preprocessed_frames', action='store_true', help='download preprocessed subset of ScanNet frames (' + PREPROCESSED_FRAMES_FILE[1] + ')')
+    parser.add_argument('--test_frames_2d', action='store_true', help='download 2D test frames (' + TEST_FRAMES_FILE[1] + '; also included with whole dataset download)')
+    parser.add_argument('--data_efficient', action='store_true', help='download data efficient task files; also included with whole dataset download)')
+    parser.add_argument('--tf_semantic', action='store_true', help='download google tensorflow records for 3D segmentation / detection')
+    parser.add_argument('--grit', action='store_true', help='download ScanNet files for General Robust Image Task')
+    parser.add_argument('--type', help='specific file type to download (.aggregation.json, .sens, .txt, _vh_clean.ply, _vh_clean_2.0.010000.segs.json, _vh_clean_2.ply, _vh_clean.segs.json, _vh_clean.aggregation.json, _vh_clean_2.labels.ply, _2d-instance.zip, _2d-instance-filt.zip, _2d-label.zip, _2d-label-filt.zip)')
+    parser.add_argument('--skip_existing', action='store_true', help='skip download of existing files when downloading full release')
+    args = parser.parse_args()
+
+    print('By pressing any key to continue you confirm that you have agreed to the ScanNet terms of use as described at:')
+    print(TOS_URL)
+    print('***')
+    print('Press any key to continue, or CTRL-C to exit.')
+    key = input('')
+
+    if args.v1:
+        global RELEASE
+        global RELEASE_TASKS
+        global RELEASE_NAME
+        global LABEL_MAP_FILE
+        RELEASE = RELEASES[V1_IDX]
+        RELEASE_TASKS = RELEASES_TASKS[V1_IDX]
+        RELEASE_NAME = RELEASES_NAMES[V1_IDX]
+        LABEL_MAP_FILE = LABEL_MAP_FILES[V1_IDX]
+        assert((not args.tf_semantic) and (not args.grit)), "Task files specified invalid for v1"
+
+    release_file = BASE_URL + RELEASE + '.txt'
+    release_scans = get_release_scans(release_file)
+    file_types = FILETYPES;
+    release_test_file = BASE_URL + RELEASE + '_test.txt'
+    release_test_scans = [] if args.v1 else get_release_scans(release_test_file)
+    file_types_test = FILETYPES_TEST;
+    out_dir_scans = os.path.join(args.out_dir, 'scans')
+    out_dir_test_scans = os.path.join(args.out_dir, 'scans_test')
+    out_dir_tasks = os.path.join(args.out_dir, 'tasks')
+
+    if args.type:  # download file type
+        file_type = args.type
+        if file_type not in FILETYPES:
+            print('ERROR: Invalid file type: ' + file_type)
+            return
+        file_types = [file_type]
+        if file_type in FILETYPES_TEST:
+            file_types_test = [file_type]
+        else:
+            file_types_test = []
+    if args.task_data:  # download task data
+        download_task_data(out_dir_tasks)
+    elif args.label_map:  # download label map file
+        download_label_map(args.out_dir)
+    elif args.preprocessed_frames:  # download preprocessed scannet_frames_25k.zip file
+        if args.v1:
+            print('ERROR: Preprocessed frames only available for ScanNet v2')
+        print('You are downloading the preprocessed subset of frames ' + PREPROCESSED_FRAMES_FILE[0] + ' which requires ' + PREPROCESSED_FRAMES_FILE[1] + ' of space.')
+        download_file(os.path.join(BASE_URL, RELEASE_TASKS, PREPROCESSED_FRAMES_FILE[0]), os.path.join(out_dir_tasks, PREPROCESSED_FRAMES_FILE[0]))
+    elif args.test_frames_2d:  # download test scannet_frames_test.zip file
+        if args.v1:
+            print('ERROR: 2D test frames only available for ScanNet v2')
+        print('You are downloading the 2D test set ' + TEST_FRAMES_FILE[0] + ' which requires ' + TEST_FRAMES_FILE[1] + ' of space.')
+        download_file(os.path.join(BASE_URL, RELEASE_TASKS, TEST_FRAMES_FILE[0]), os.path.join(out_dir_tasks, TEST_FRAMES_FILE[0]))
+    elif args.data_efficient: # download data efficient task files
+        print('You are downloading the data efficient task files' + ' which requires ' + DATA_EFFICIENT_FILES[-1] + ' of space.')
+        for k in range(len(DATA_EFFICIENT_FILES)-1):
+            download_file(os.path.join(BASE_URL, RELEASE_TASKS, DATA_EFFICIENT_FILES[k]), os.path.join(out_dir_tasks, DATA_EFFICIENT_FILES[k]))
+    elif args.tf_semantic: # download google tf records
+        download_tfrecords(os.path.join(BASE_URL, RELEASE_TASKS, 'tf3d'), os.path.join(out_dir_tasks, 'tf3d'))
+    elif args.grit: # download GRIT file
+        download_file(os.path.join(BASE_URL, RELEASE_TASKS, GRIT_FILES[0]), os.path.join(out_dir_tasks, GRIT_FILES[0]))
+    elif args.id:  # download single scan
+        scan_id = args.id
+        is_test_scan = scan_id in release_test_scans
+        if scan_id not in release_scans and (not is_test_scan or args.v1):
+            print('ERROR: Invalid scan id: ' + scan_id)
+        else:
+            out_dir = os.path.join(out_dir_scans, scan_id) if not is_test_scan else os.path.join(out_dir_test_scans, scan_id)
+            scan_file_types = file_types if not is_test_scan else file_types_test
+            use_v1_sens = not is_test_scan
+            if not is_test_scan and not args.v1 and '.sens' in scan_file_types:
+                print('Note: ScanNet v2 uses the same .sens files as ScanNet v1: Press \'n\' to exclude downloading .sens files for each scan')
+                key = input('')
+                if key.strip().lower() == 'n':
+                    scan_file_types.remove('.sens')
+            download_scan(scan_id, out_dir, scan_file_types, use_v1_sens, skip_existing=args.skip_existing)
+    else:  # download entire release
+        if len(file_types) == len(FILETYPES):
+            print('WARNING: You are downloading the entire ScanNet ' + RELEASE_NAME + ' release which requires ' + RELEASE_SIZE + ' of space.')
+        else:
+            print('WARNING: You are downloading all ScanNet ' + RELEASE_NAME + ' scans of type ' + file_types[0])
+        print('Note that existing scan directories will be skipped. Delete partially downloaded directories to re-download.')
+        print('***')
+        print('Press any key to continue, or CTRL-C to exit.')
+        key = input('')
+        if not args.v1 and '.sens' in file_types:
+            print('Note: ScanNet v2 uses the same .sens files as ScanNet v1: Press \'n\' to exclude downloading .sens files for each scan')
+            key = input('')
+            if key.strip().lower() == 'n':
+                file_types.remove('.sens')
+        download_release(release_scans, out_dir_scans, file_types, use_v1_sens=True, skip_existing=args.skip_existing)
+        if not args.v1:
+            download_label_map(args.out_dir)
+            download_release(release_test_scans, out_dir_test_scans, file_types_test, use_v1_sens=False, skip_existing=args.skip_existing)
+            download_file(os.path.join(BASE_URL, RELEASE_TASKS, TEST_FRAMES_FILE[0]), os.path.join(out_dir_tasks, TEST_FRAMES_FILE[0]))
+            for k in range(len(DATA_EFFICIENT_FILES)-1):
+                download_file(os.path.join(BASE_URL, RELEASE_TASKS, DATA_EFFICIENT_FILES[k]), os.path.join(out_dir_tasks, DATA_EFFICIENT_FILES[k]))
+
+
+if __name__ == "__main__": main()

--- a/custom/helpers/download_paper_scenes.sh
+++ b/custom/helpers/download_paper_scenes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -u
+
+PAIRS_SRC=/home/spark1/yarden/QBench2/QBench-Release/custom/SuperGluePretrainedNetwork/assets/scannet_test_pairs_with_gt.txt
+SCANNET_ROOT=/data/scannet/ref
+NUM_SCENES=100
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SCENES_LIST=/tmp/scannet_test_scenes.txt
+LOG="$SCANNET_ROOT/_download.log"
+
+mkdir -p "$SCANNET_ROOT"
+
+python3 - "$PAIRS_SRC" "$NUM_SCENES" "$SCENES_LIST" <<'PY'
+import sys
+src, n, out = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+seen = []
+seen_set = set()
+with open(src) as f:
+    for line in f:
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        for p in (parts[0], parts[1]):
+            s = p.split('/')[1]
+            if s not in seen_set:
+                seen_set.add(s)
+                seen.append(s)
+        if n > 0 and len(seen) >= n:
+            break
+if n > 0:
+    seen = seen[:n]
+with open(out, 'w') as g:
+    g.write('\n'.join(seen) + '\n')
+print(f'selected {len(seen)} scenes -> {out}')
+PY
+
+echo "=== start $(date -Iseconds) ===" >> "$LOG"
+while IFS= read -r scene; do
+  [ -z "$scene" ] && continue
+  echo "--- $scene $(date -Iseconds) ---" >> "$LOG"
+  printf '\n' | python3 "$DIR/download-scannet.py" -o "$SCANNET_ROOT" --id "$scene" --type .sens --skip_existing >> "$LOG" 2>&1
+done < "$SCENES_LIST"
+echo "=== done $(date -Iseconds) ===" >> "$LOG"
+
+echo "downloaded $NUM_SCENES scenes to $SCANNET_ROOT/scans_test (log: $LOG)"

--- a/custom/helpers/download_scannet_test.sh
+++ b/custom/helpers/download_scannet_test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+SCRIPT="/home/spark1/yarden/QBench2/QBench-Release/custom/helpers/download-scannet.py"
+OUT=/data/scannet/ref
+LOG=/data/scannet/ref/_download.log
+SCENE_LIST="${1:-/tmp/scannet_test_scenes.txt}"
+echo "=== start $(date -Iseconds) list=$SCENE_LIST ===" >> "$LOG"
+while IFS= read -r scene; do
+  [ -z "$scene" ] && continue
+  echo "--- $scene $(date -Iseconds) ---" >> "$LOG"
+  # Script prompts once for TOS confirmation; feed one empty line.
+  printf '\n' | python3 "$SCRIPT" -o "$OUT" --id "$scene" --type .sens --skip_existing >> "$LOG" 2>&1
+done < "$SCENE_LIST"
+echo "=== done $(date -Iseconds) ===" >> "$LOG"

--- a/custom/helpers/extract.py
+++ b/custom/helpers/extract.py
@@ -1,0 +1,57 @@
+"""Extract only the frames referenced by scannet_test_pairs_with_gt.txt from
+raw .sens files, writing JPEG bytes directly (no decompress/re-encode)."""
+import os, struct, json, sys
+
+NEEDED = json.load(open('/tmp/scannet_extract/needed.json'))
+ROOT_IN  = '/data/scannet/ref/scans_test'
+ROOT_OUT = '/data/scannet/ref/scans_test'   # in-place: write {scene}/sens/frame-NNNNNN.color.jpg
+
+HDR_FIXED = 4 + 8  # version + strlen uint64 (then sensor name variable)
+
+def extract_scene(scene: str, needed_frames: set[int]) -> None:
+    sens_path = f'{ROOT_IN}/{scene}/{scene}.sens'
+    out_dir = f'{ROOT_OUT}/{scene}/sens'
+    os.makedirs(out_dir, exist_ok=True)
+
+    with open(sens_path, 'rb') as f:
+        version = struct.unpack('I', f.read(4))[0]
+        assert version == 4, f'unexpected version {version}'
+        strlen = struct.unpack('Q', f.read(8))[0]
+        f.seek(strlen, 1)                                  # sensor_name
+        f.seek(16*4 * 4, 1)                                # 4 × (16 floats)
+        f.seek(4 + 4, 1)                                   # color/depth compression enum
+        color_w, color_h, depth_w, depth_h = struct.unpack('IIII', f.read(16))
+        f.seek(4, 1)                                       # depth_shift
+        num_frames = struct.unpack('Q', f.read(8))[0]
+
+        remaining = set(needed_frames)
+        written = 0
+        for idx in range(num_frames):
+            if not remaining:
+                break
+            # per-frame header: 64 (cam_to_world) + 8 + 8 + 8 + 8
+            f.seek(16*4, 1)
+            ts_c, ts_d = struct.unpack('QQ', f.read(16))
+            color_size = struct.unpack('Q', f.read(8))[0]
+            depth_size = struct.unpack('Q', f.read(8))[0]
+            if idx in remaining:
+                data = f.read(color_size)
+                with open(f'{out_dir}/frame-{idx:06d}.color.jpg', 'wb') as g:
+                    g.write(data)
+                f.seek(depth_size, 1)
+                remaining.discard(idx)
+                written += 1
+            else:
+                f.seek(color_size + depth_size, 1)
+        missing = sorted(remaining)
+    print(f'  {scene}: wrote {written}/{len(needed_frames)}; num_frames={num_frames}; '
+          f'color={color_w}x{color_h}; missing={missing}')
+
+
+def main():
+    for scene in sorted(NEEDED):
+        extract_scene(scene, set(NEEDED[scene]))
+
+
+if __name__ == '__main__':
+    main()

--- a/custom/helpers/extract_paper_frames.sh
+++ b/custom/helpers/extract_paper_frames.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -u
+
+PAIRS_SRC=/home/spark1/yarden/QBench2/QBench-Release/custom/SuperGluePretrainedNetwork/assets/scannet_test_pairs_with_gt.txt
+SCANNET_ROOT=/data/scannet/ref
+NUM_SCENES=100
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+NEEDED_JSON=/tmp/scannet_extract/needed.json
+mkdir -p "$(dirname "$NEEDED_JSON")"
+
+python3 - "$PAIRS_SRC" "$NUM_SCENES" "$NEEDED_JSON" <<'PY'
+import sys, json
+src, n, out = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+order = []
+order_set = set()
+pair_rows = []
+with open(src) as f:
+    for line in f:
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        s0 = parts[0].split('/')[1]
+        s1 = parts[1].split('/')[1]
+        for s in (s0, s1):
+            if s not in order_set:
+                order_set.add(s)
+                order.append(s)
+        pair_rows.append((s0, s1, parts[0], parts[1]))
+selected = set(order[:n] if n > 0 else order)
+needed = {}
+for s0, s1, p0, p1 in pair_rows:
+    if s0 in selected and s1 in selected:
+        for scene, path in ((s0, p0), (s1, p1)):
+            idx = int(path.split('/')[-1].split('-')[1].split('.')[0])
+            needed.setdefault(scene, set()).add(idx)
+needed = {k: sorted(v) for k, v in needed.items()}
+with open(out, 'w') as g:
+    json.dump(needed, g)
+total = sum(len(v) for v in needed.values())
+print(f'selected {len(needed)} scenes, {total} unique frames -> {out}')
+PY
+
+python3 "$DIR/extract.py"
+
+echo "extracted frames for $NUM_SCENES scenes under $SCANNET_ROOT/scans_test"

--- a/custom/helpers/make_paper_pairs.sh
+++ b/custom/helpers/make_paper_pairs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -u
+
+PAIRS_SRC=/home/spark1/yarden/QBench2/QBench-Release/custom/SuperGluePretrainedNetwork/assets/scannet_test_pairs_with_gt.txt
+NUM_SCENES=100
+PAIRS_OUT=/home/spark1/yarden/QBench2/QBench-Release/runspace/inputs/scannet/pairs_test_paper_100scenes.txt
+
+mkdir -p "$(dirname "$PAIRS_OUT")"
+
+python3 - "$PAIRS_SRC" "$NUM_SCENES" "$PAIRS_OUT" <<'PY'
+import sys
+src, n, out = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+order = []
+order_set = set()
+rows = []
+with open(src) as f:
+    for line in f:
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        s0 = parts[0].split('/')[1]
+        s1 = parts[1].split('/')[1]
+        for s in (s0, s1):
+            if s not in order_set:
+                order_set.add(s)
+                order.append(s)
+        rows.append((s0, s1, line))
+selected = set(order[:n] if n > 0 else order)
+kept = [ln for s0, s1, ln in rows if s0 in selected and s1 in selected]
+with open(out, 'w') as g:
+    g.writelines(kept)
+print(f'wrote {len(kept)} pairs across {len(selected)} scenes -> {out}')
+PY

--- a/custom/helpers/make_scene_list.py
+++ b/custom/helpers/make_scene_list.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Emit the ordered scene list referenced by the SuperGlue paper pairs file.
+
+Scenes are deduplicated and kept in first-seen order, matching the scene order
+used by extract_paper_frames.sh and make_paper_pairs.sh. Optionally filters to
+scenes not already present on disk (useful for feeding download_scannet_test.sh).
+"""
+import argparse
+import os
+import sys
+
+DEFAULT_PAIRS = "/home/spark1/yarden/QBench2/QBench-Release/custom/SuperGluePretrainedNetwork/assets/scannet_test_pairs_with_gt.txt"
+DEFAULT_ROOT = "/data/scannet/ref/scans_test"
+
+
+def ordered_scenes(pairs_file):
+    order, seen = [], set()
+    with open(pairs_file) as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            for p in (parts[0], parts[1]):
+                s = p.split("/")[1]
+                if s not in seen:
+                    seen.add(s)
+                    order.append(s)
+    return order
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", default=DEFAULT_PAIRS)
+    ap.add_argument("--root", default=DEFAULT_ROOT,
+                    help="scans_test root; used with --missing-only")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="keep first N scenes (0 = all)")
+    ap.add_argument("--missing-only", action="store_true",
+                    help="emit only scenes whose <scene>.sens is absent under --root")
+    ap.add_argument("--out", default="-",
+                    help="output path (default stdout)")
+    args = ap.parse_args()
+
+    scenes = ordered_scenes(args.pairs)
+    if args.limit > 0:
+        scenes = scenes[:args.limit]
+    if args.missing_only:
+        scenes = [s for s in scenes
+                  if not os.path.isfile(os.path.join(args.root, s, f"{s}.sens"))]
+
+    body = "\n".join(scenes) + ("\n" if scenes else "")
+    if args.out == "-":
+        sys.stdout.write(body)
+    else:
+        os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+        with open(args.out, "w") as g:
+            g.write(body)
+        print(f"wrote {len(scenes)} scenes -> {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,4 @@ services:
     volumes:
       - ./:/app
       - ${IMAGENET_HOST_PATH:-/data/imagenet}:/data/imagenet
+      - ${SCANNET_HOST_PATH:-/data/shared_data/scannet/scannet}:/data/scannet:ro

--- a/dockerfile
+++ b/dockerfile
@@ -29,7 +29,7 @@ RUN python -m pip install --no-cache-dir --upgrade pip && \
     streamlit \
     timm \
     torchview \
-    opencv-python \
+    opencv-python-headless \
     nvidia-ml-py
 
 WORKDIR /app

--- a/runspace/inputs/base_configs/sg_only_scannet_paper.yaml
+++ b/runspace/inputs/base_configs/sg_only_scannet_paper.yaml
@@ -2,6 +2,7 @@ target_pipeline: superpoint_superglue
 
 adapter:
   type: feature_matching
+  quantize_components: ["superglue"]
   quantized_ops: ["all"]
   weight_quantization: true
   input_quantization: true

--- a/runspace/inputs/base_configs/sg_only_scannet_paper_chunk.yaml
+++ b/runspace/inputs/base_configs/sg_only_scannet_paper_chunk.yaml
@@ -2,13 +2,17 @@ target_pipeline: superpoint_superglue
 
 adapter:
   type: feature_matching
+  quantize_components: ["superglue"]
   quantized_ops: ["all"]
   weight_quantization: true
   input_quantization: true
 
 quantization:
   format: fp8_e4m3
-  weight_mode: channel
+  mode: chunk
+  chunk_size: 128
+  weight_chunk_size: 128
+  weight_mode: chunk
   calib_method: max
   strict_format_check: true
 

--- a/runspace/inputs/base_configs/sp_sg_scannet_100subset.yaml
+++ b/runspace/inputs/base_configs/sp_sg_scannet_100subset.yaml
@@ -14,15 +14,20 @@ quantization:
 
 dataset:
   name: scannet_pairs
-  path: /data/scannet/posed_images
-  pairs_file: /app/runspace/inputs/scannet/pairs_val_1500.txt
+  path: /data/scannet/ref
+  pairs_file: /app/runspace/inputs/scannet/pairs_test_paper_100subset.txt
   image_size: [480, 640]
   batch_size: 1
-  num_workers: 8
-  max_pairs: 1500
+  num_workers: 0
+  max_pairs: 100
+
+model:
+  sp_config:
+    max_keypoints: 1024
 
 evaluation:
   mode: compare
-  save_visualizations: true
-  num_viz_samples: 1500
+  save_visualizations: false
+  num_viz_samples: 0
   compare_batches: -1
+  max_batches: -1

--- a/runspace/inputs/base_configs/sp_sg_scannet_20subset.yaml
+++ b/runspace/inputs/base_configs/sp_sg_scannet_20subset.yaml
@@ -12,17 +12,23 @@ quantization:
   calib_method: max
   strict_format_check: true
 
+# Diagnostic subset: first 20 pairs, for apples-to-apples compare vs upstream match_pairs.py
 dataset:
   name: scannet_pairs
-  path: /data/scannet/posed_images
-  pairs_file: /app/runspace/inputs/scannet/pairs_val_1500.txt
+  path: /data/scannet/ref
+  pairs_file: /app/runspace/inputs/scannet/pairs_test_paper_20subset.txt
   image_size: [480, 640]
   batch_size: 1
-  num_workers: 8
-  max_pairs: 1500
+  num_workers: 0
+  max_pairs: 20
+
+model:
+  sp_config:
+    max_keypoints: 1024
 
 evaluation:
   mode: compare
-  save_visualizations: true
-  num_viz_samples: 1500
+  save_visualizations: false
+  num_viz_samples: 0
   compare_batches: -1
+  max_batches: -1

--- a/runspace/inputs/base_configs/sp_sg_scannet_local_fp8e4m3_gt.yaml
+++ b/runspace/inputs/base_configs/sp_sg_scannet_local_fp8e4m3_gt.yaml
@@ -13,15 +13,15 @@ quantization:
 
 dataset:
   name: scannet_pairs
-  path: D:/scannet/posed_images
-  pairs_file: D:/scannet/pairs_val.txt
+  path: /data/scannet/posed_images
+  pairs_file: /app/runspace/inputs/scannet/pairs_val_1500.txt
   image_size: [480, 640]
   batch_size: 1
-  num_workers: 0
-  max_pairs: 100
+  num_workers: 8
+  max_pairs: 1500
 
 evaluation:
   mode: compare
   save_visualizations: true
-  num_viz_samples: 15
+  num_viz_samples: 1500
   compare_batches: -1

--- a/runspace/inputs/base_configs/sp_sg_scannet_local_fp8e4m3_gt.yaml
+++ b/runspace/inputs/base_configs/sp_sg_scannet_local_fp8e4m3_gt.yaml
@@ -10,6 +10,7 @@ quantization:
   format: fp8_e4m3
   weight_mode: channel
   calib_method: max
+  strict_format_check: true
 
 dataset:
   name: scannet_pairs
@@ -22,6 +23,6 @@ dataset:
 
 evaluation:
   mode: compare
-  save_visualizations: true
-  num_viz_samples: 1500
+  save_visualizations: false
+  num_viz_samples: 15
   compare_batches: -1

--- a/runspace/inputs/base_configs/sp_sg_scannet_paper.yaml
+++ b/runspace/inputs/base_configs/sp_sg_scannet_paper.yaml
@@ -12,17 +12,25 @@ quantization:
   calib_method: max
   strict_format_check: true
 
+# Paper-aligned ScanNet benchmark: SuperGlue's own test pairs
+# (assets/scannet_test_pairs_with_gt.txt) covering all 100 test scenes.
+# Yields the full 1500 paper pairs.
 dataset:
   name: scannet_pairs
-  path: /data/scannet/posed_images
-  pairs_file: /app/runspace/inputs/scannet/pairs_val_1500.txt
+  path: /data/scannet/ref
+  pairs_file: /app/runspace/inputs/scannet/pairs_test_paper_100scenes.txt
   image_size: [480, 640]
   batch_size: 1
   num_workers: 8
   max_pairs: 1500
 
+model:
+  sp_config:
+    max_keypoints: 1024
+
 evaluation:
   mode: compare
-  save_visualizations: true
+  save_visualizations: false
   num_viz_samples: 1500
   compare_batches: -1
+  max_batches: -1

--- a/runspace/inputs/base_configs/sp_sg_scannet_paper_chunk.yaml
+++ b/runspace/inputs/base_configs/sp_sg_scannet_paper_chunk.yaml
@@ -8,7 +8,10 @@ adapter:
 
 quantization:
   format: fp8_e4m3
-  weight_mode: channel
+  mode: chunk
+  chunk_size: 128
+  weight_chunk_size: 128
+  weight_mode: chunk
   calib_method: max
   strict_format_check: true
 

--- a/runspace/inputs/models.yaml
+++ b/runspace/inputs/models.yaml
@@ -29,3 +29,8 @@
 - name: mobilevit_xxs
   source: timm
   weights: DEFAULT
+
+- name: superpoint_superglue
+  source: custom
+  repo_path: /app/custom/SuperGluePretrainedNetwork
+  sg_weights: indoor

--- a/runspace/src/adapters/adapter_factory.py
+++ b/runspace/src/adapters/adapter_factory.py
@@ -122,6 +122,11 @@ def create_adapter(config: dict) -> BaseAdapter:
     # Check if per-chunk format mode is enabled
     per_chunk_format = quantization_config.get('per_chunk_format', False)
 
+    # Opt-in: when true, the FP8 compliance table validates each tensor against
+    # the grid of its own declared format (weight/input/output) rather than a
+    # single per-module q_type. Default False to preserve existing behavior.
+    strict_format_check = quantization_config.get('strict_format_check', False)
+
     # If nothing is requested to be quantized, avoid the quantized build path.
     # This keeps pure FP32 / file-backed state-dict runs on a simpler, safer path.
     qops_list = quantized_ops if isinstance(quantized_ops, list) else [quantized_ops]
@@ -163,6 +168,7 @@ def create_adapter(config: dict) -> BaseAdapter:
             run_id=run_id,
             skip_calibration=skip_calibration,
             build_quantized=build_quantized,
+            strict_format_check=strict_format_check,
         )
         if _should_print_adapter_config(config):
             _print_adapter_config_snapshot(config, adapter_type, resolved_kwargs)
@@ -219,6 +225,7 @@ def create_adapter(config: dict) -> BaseAdapter:
             skip_calibration=skip_calibration,
             build_quantized=build_quantized,
             quantize_components=adapter_config.get('quantize_components', []),
+            strict_format_check=strict_format_check,
         )
         if _should_print_adapter_config(config):
             _print_adapter_config_snapshot(config, adapter_type, resolved_kwargs)
@@ -316,7 +323,7 @@ def validate_config(config: dict):
     schema = {
         'model': ['name', 'source', 'weights', 'repo_path', 'sg_weights', 'sp_config', 'sg_config'],
         'adapter': ['type', 'quantize_first_layer', 'quantized_ops', 'excluded_ops', 'input_quantization', 'weight_quantization', 'quantization_type', 'layers', 'fold_layers', 'input_quantization_type', 'input_chunk_size', 'skip_calibration', 'build_quantized', 'quantize_components'],
-        'quantization': ['format', 'bias', 'calib_method', 'layers', 'type', 'enabled', 'input_format', 'mode', 'chunk_size', 'weight_mode', 'weight_chunk_size', 'act_mode', 'act_chunk_size', 'simulate_tf32_accum', 'rounding', 'per_chunk_format'],
+        'quantization': ['format', 'bias', 'calib_method', 'layers', 'type', 'enabled', 'input_format', 'mode', 'chunk_size', 'weight_mode', 'weight_chunk_size', 'act_mode', 'act_chunk_size', 'simulate_tf32_accum', 'rounding', 'per_chunk_format', 'strict_format_check'],
         'dataset': ['name', 'path', 'batch_size', 'num_workers', 'image_size', 'grayscale', 'pairs_file', 'max_pairs', 'resize_size', 'multiprocessing_context', 'persistent_workers', 'prefetch_factor'],
         'evaluation': ['mode', 'compare_batches', 'dataset', 'batch_size', 'max_samples', 'generate_graph_svg', 'save_histograms', 'max_batches', 'graph_only', 'dynamic_input_quant', 'input_quant', 'save_visualizations', 'num_viz_samples']
     }

--- a/runspace/src/adapters/feature_matching_adapter.py
+++ b/runspace/src/adapters/feature_matching_adapter.py
@@ -52,6 +52,7 @@ class FeatureMatchingAdapter(GenericAdapter):
         skip_calibration: bool = False,
         build_quantized: bool = True,
         quantize_components: list = None,
+        strict_format_check: bool = False,
     ):
         self._pipeline_name = pipeline_name
         self._model_cfg = model_cfg
@@ -81,6 +82,7 @@ class FeatureMatchingAdapter(GenericAdapter):
             skip_calibration=skip_calibration,
             build_quantized=build_quantized,
             target_module_prefixes=target_prefixes,
+            strict_format_check=strict_format_check,
         )
 
     def build_model(self, quantized: bool = False) -> nn.Module:

--- a/runspace/src/adapters/generic_adapter.py
+++ b/runspace/src/adapters/generic_adapter.py
@@ -48,6 +48,7 @@ class GenericAdapter(BaseAdapter):
         skip_calibration: bool = False,
         build_quantized: bool = True,
         target_module_prefixes: list = None,
+        strict_format_check: bool = False,
     ):
         super().__init__()
         self.target_module_prefixes = target_module_prefixes or []
@@ -83,6 +84,7 @@ class GenericAdapter(BaseAdapter):
         self.simulate_tf32_accum = simulate_tf32_accum
         self.rounding = rounding
         self.input_chunk_size = input_chunk_size
+        self.strict_format_check = bool(strict_format_check)
         if not self.build_quantized:
             print(
                 f"GenericAdapter: build_quantized=False for {self.model_name} "
@@ -441,6 +443,64 @@ class GenericAdapter(BaseAdapter):
         """Replace standard layers with quantized versions."""
         self._first_layer_found = False
         self._recursive_replace(model)
+        self._configure_remaining_mixin_ops(model)
+
+    def _configure_remaining_mixin_ops(self, model: nn.Module):
+        """Propagate adapter config + per-layer overrides to QuantizedLayerMixin ops
+        that weren't touched by _recursive_replace. Covers Observed* ops registered
+        without original_cls (ObservedAttentionScores / Apply / Concat / Add /
+        DescMatmul) whose q_type would otherwise stay at the ctor default regardless
+        of what config.yaml says."""
+        # Match the absolute prefix SuperGlue uses ([superglue.py:51]) so the
+        # QuantizedLayerMixin class identity is the same as the one Observed* ops
+        # inherit from. A relative import would bind to src.ops.quant_base (a
+        # separate module when both runspace/ and the repo root are on sys.path).
+        from runspace.src.ops.quant_base import QuantizedLayerMixin
+
+        supported_ops_values = tuple(OpRegistry.get_supported_ops().values())
+
+        for full_name, module in model.named_modules():
+            if not isinstance(module, QuantizedLayerMixin):
+                continue
+            # Already configured by Case 1/2 (class is a registered quantized op).
+            if type(module) in supported_ops_values:
+                continue
+
+            # Resolve settings: global config + per-layer override
+            # (mirrors _create_quantized_module's resolution block).
+            q_type = self.quantization_type
+            bias = self.quantization_bias
+            input_q_type = self.input_quantization_type
+            input_mode = self.quant_mode
+            input_chunk_size = self.input_chunk_size if self.input_chunk_size is not None else self.chunk_size
+            rounding = self.rounding
+
+            layer_conf = self.layer_config.get(full_name, {}) if isinstance(self.layer_config, dict) else {}
+            if 'type' in layer_conf:
+                q_type = layer_conf['type']
+            elif 'format' in layer_conf:
+                q_type = layer_conf['format']
+            if 'bias' in layer_conf:
+                bias = layer_conf['bias']
+            if 'input_format' in layer_conf:
+                input_q_type = layer_conf['input_format']
+            if 'mode' in layer_conf:
+                input_mode = layer_conf['mode']
+            if 'chunk_size' in layer_conf:
+                input_chunk_size = layer_conf['chunk_size']
+            if 'rounding' in layer_conf:
+                rounding = layer_conf['rounding']
+
+            module.q_type = q_type
+            module.quantization_bias = bias
+            module.input_q_type = input_q_type if input_q_type else q_type
+            module.input_quantization = self.input_quantization
+            module.weight_quantization = self.weight_quantization
+            module.input_mode = input_mode
+            module.input_chunk_size = input_chunk_size
+            module.rounding = rounding
+            module.layer_name = full_name
+            module.run_id = getattr(self, 'run_id', 'default')
 
     def _create_quantized_module(self, module: nn.Module, QuantClass: type, name: str = "") -> nn.Module:
         """Creates a quantized module from the original module."""

--- a/runspace/src/datasets/scannet_pairs.py
+++ b/runspace/src/datasets/scannet_pairs.py
@@ -1,8 +1,8 @@
 import os
+import cv2
+import numpy as np
 import torch
-from PIL import Image
 from torch.utils.data import Dataset, DataLoader
-from torchvision import transforms as T
 
 from src.datasets.dataset_registry import register_dataset
 
@@ -13,18 +13,15 @@ def _resolve_path(path: str, root: str) -> str:
     return os.path.join(root, path)
 
 
-def _build_resize(size) -> T.Resize:
-    if isinstance(size, (list, tuple)):
-        return T.Resize(list(size))
-    return T.Resize(size)
-
-
-def _load_image(path: str, grayscale: bool, resize: T.Resize) -> torch.Tensor:
-    img = Image.open(path).convert('RGB')
-    img = resize(img)
-    if grayscale:
-        img = T.Grayscale(num_output_channels=1)(img)
-    return T.ToTensor()(img)
+def _read_gray(path: str, new_w: int, new_h: int) -> tuple[torch.Tensor, int, int]:
+    """Mirror SuperGlue match_pairs.py read_image: decode as luma JPEG, cv2-resize."""
+    img = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        raise FileNotFoundError(f"could not read image: {path}")
+    orig_h, orig_w = img.shape[:2]
+    img = cv2.resize(img, (new_w, new_h))
+    tensor = torch.from_numpy(img.astype(np.float32) / 255.0)[None]
+    return tensor, orig_w, orig_h
 
 
 def _scale_K(K: torch.Tensor, orig_w: int, orig_h: int,
@@ -79,7 +76,6 @@ class ScanNetPairsDataset(Dataset):
                  max_pairs: int = -1):
         self.root = root
         self.image_size = image_size
-        self.resize = _build_resize(image_size)
         self.pairs = _parse_pairs_file(pairs_file)
         if max_pairs > 0:
             self.pairs = self.pairs[:max_pairs]
@@ -92,18 +88,9 @@ class ScanNetPairsDataset(Dataset):
         path0 = _resolve_path(p['img0'], self.root)
         path1 = _resolve_path(p['img1'], self.root)
 
-        orig0 = Image.open(path0)
-        orig_w0, orig_h0 = orig0.size
-        orig1 = Image.open(path1)
-        orig_w1, orig_h1 = orig1.size
-
         new_h, new_w = self.image_size
-        img0 = self.resize(orig0.convert('RGB'))
-        img0 = T.Grayscale(num_output_channels=1)(img0)
-        img0 = T.ToTensor()(img0)
-        img1 = self.resize(orig1.convert('RGB'))
-        img1 = T.Grayscale(num_output_channels=1)(img1)
-        img1 = T.ToTensor()(img1)
+        img0, orig_w0, orig_h0 = _read_gray(path0, new_w, new_h)
+        img1, orig_w1, orig_h1 = _read_gray(path1, new_w, new_h)
 
         K0 = _scale_K(p['K0'], orig_w0, orig_h0, new_w, new_h)
         K1 = _scale_K(p['K1'], orig_w1, orig_h1, new_w, new_h)

--- a/runspace/src/eval/comparator.py
+++ b/runspace/src/eval/comparator.py
@@ -37,6 +37,12 @@ class LayerComparator:
         self.quant_certainty_sum = 0.0
         self.total_batches = 0
         self.layer_metrics = {}
+        # Opt-in: when True, the FP8 compliance table validates each tensor
+        # against its own declared format (weight_fp8 vs. module.q_type,
+        # last_quant_input_unscaled vs. module.input_q_type, activation output
+        # vs. module.q_type). When False, the existing single-format-per-module
+        # behavior is preserved.
+        self.strict_format_check = bool(getattr(adapter, 'strict_format_check', False))
         
         # Compression Stats
         from src.eval.compression import CompressionTracker
@@ -123,8 +129,9 @@ class LayerComparator:
             if len(list(module.children())) == 0 or isinstance(module, DecomposedMultiheadAttention):
                 module.register_forward_hook(get_hook(name))
                 
-                # Enable internal capture for Quant layers
-                if isinstance(module, quantized_ops):
+                # Enable internal capture for Quant layers (including QuantizedLayerMixin-only
+                # ops like Observed* modules that aren't registered with original_cls).
+                if isinstance(module, quantized_ops) or isinstance(module, QuantizedLayerMixin):
                     module.capture_activations = True
 
     def compare(self, data_loader, num_batches=1, global_metrics=None):
@@ -630,9 +637,14 @@ class LayerComparator:
                 return f"{RED}{_wpad(status, width)}{RESET}"
 
         report_lines.append("--- FP8 Compliance Check (Value-Based) ---")
-        _NAME_W, _TYPE_W, _SHAPE_W, _CHECK_W = 52, 28, 18, 22
-        _SEP_W = _NAME_W + _TYPE_W + _SHAPE_W + 2 * _CHECK_W + 4 * 3
-        report_lines.append(f"{'Layer':<{_NAME_W}} | {'Type':<{_TYPE_W}} | {'Shape':<{_SHAPE_W}} | {'Weight Check':<{_CHECK_W}} | {'Input Check':<{_CHECK_W}}")
+        _NAME_W, _TYPE_W, _SHAPE_W, _CHECK_W, _FMT_W, _IQ_W = 52, 28, 18, 22, 12, 10
+        _SEP_W = _NAME_W + _TYPE_W + _SHAPE_W + 3 * _FMT_W + _IQ_W + _FMT_W + 2 * _CHECK_W + 9 * 3
+        report_lines.append(
+            f"{'Layer':<{_NAME_W}} | {'Type':<{_TYPE_W}} | {'Shape':<{_SHAPE_W}} | "
+            f"{'Weight Fmt':<{_FMT_W}} | {'Input Q?':<{_IQ_W}} | {'Pre-Quant':<{_FMT_W}} | "
+            f"{'Input Fmt':<{_FMT_W}} | {'Output Fmt':<{_FMT_W}} | "
+            f"{'Weight Check':<{_CHECK_W}} | {'Input Check':<{_CHECK_W}}"
+        )
         report_lines.append("-" * _SEP_W)
         
         # Import FP8/FP4/INT8 table getters and compliance checker
@@ -667,6 +679,63 @@ class LayerComparator:
         # Pre-fetch tables (cached per-format, keyed by q_type string)
         device = next(self.quant_model.parameters()).device
         _table_cache = {}
+        strict = self.strict_format_check
+
+        def _fmt_strings(module):
+            """Return (weight_fmt, input_quantized, pre_quant_fmt, input_fmt, output_fmt)
+            strings for a module. Uses duck-typing on module attributes so the result
+            is independent of which QuantizedLayerMixin module a given class was loaded
+            from (the project has both `src.ops.quant_base` and
+            `runspace.src.ops.quant_base` live at the same time)."""
+            cls_name = module.__class__.__name__
+            is_activation = OpRegistry.is_activation(cls_name)
+            # Weight fmt: only ops that carry trainable weights.
+            if hasattr(module, 'weight') and module.weight is not None:
+                w = getattr(module, 'q_type', None) or 'N/A'
+            else:
+                w = 'N/A'
+            # Input fmt + "input quantized?" flag.
+            # Every layer receives an FP32 tensor on the wire (the previous op emits
+            # an FP32 accumulator regardless of target format), so pre-quant is FP32
+            # whenever the layer actually rounds its input.
+            if getattr(module, 'input_quantization', False):
+                iq = 'Yes'
+                pq = 'FP32'
+                i = getattr(module, 'input_q_type', None) or getattr(module, 'q_type', None) or 'N/A'
+            elif is_activation and hasattr(module, 'q_type') and module.q_type is not None:
+                iq = 'Yes'
+                pq = 'FP32'
+                i = module.q_type
+            else:
+                iq = 'No'
+                pq = 'N/A'
+                i = 'N/A'
+            # Output fmt: activation ops quantize output via q_type; other quantized
+            # ops (conv/matmul) emit FP32 accumulators; everything else is N/A.
+            if is_activation:
+                o = getattr(module, 'q_type', None) or 'N/A'
+            elif hasattr(module, 'q_type') and module.q_type is not None:
+                o = 'FP32'
+            else:
+                o = 'N/A'
+            return w, iq, pq, i, o
+
+        def _check_for_fmt(tensor, fmt):
+            """Validate tensor against the grid of the given format string.
+            Used only when strict_format_check is enabled. Returns the same
+            (passed, inv_count, examples) tuple shape as _compliance_check,
+            or None if the format is unrecognised."""
+            if fmt in (None, 'N/A', 'FP32'):
+                return None
+            if fmt not in _table_cache:
+                _table_cache[fmt] = get_format_table(fmt, device)
+            table = _table_cache[fmt]
+            mb = _parse_mant_bits(fmt) if fmt not in _NATIVE_FORMATS else None
+            if table is None and mb is None:
+                return None
+            if table is None:
+                return _check_mantissa_precision(tensor, mb)
+            return check_fp8_compliance(tensor, table)
         
         # Determine global q_type from the model (check first quantized layer)
         global_q_type = 'fp8_e4m3'
@@ -705,6 +774,11 @@ class LayerComparator:
                 if name not in seen:
                     modules_to_process.append((name, module))
 
+        # Track the last non-passthrough layer's Output Fmt so pass-through rows
+        # can inherit it (a pass-through op receives and emits the same tensor,
+        # so its "flowing format" is whatever the upstream op produced).
+        prev_output_fmt = 'N/A'
+
         for name, module in modules_to_process:
             # Check leaf modules or DecomposedMHA
             if len(list(module.children())) == 0 or isinstance(module, DecomposedMultiheadAttention):
@@ -730,7 +804,35 @@ class LayerComparator:
                     shape_str = "N/A"
                     if name in self.ref_activations:
                         shape_str = str(tuple(self.ref_activations[name].shape[1:]))
-                    report_lines.append(f"{name:<{_NAME_W}} | {layer_type:<{_TYPE_W}} | {shape_str:<{_SHAPE_W}} | {passthrough_str} | {passthrough_str}")
+
+                    # Pass-through ops receive and emit the same tensor, so the
+                    # "flowing format" is whatever the previous non-passthrough
+                    # layer produced. Default to FP32 when there's no predecessor
+                    # or the predecessor emitted a raw accumulator.
+                    flow_fmt = prev_output_fmt if prev_output_fmt not in ('N/A', None) else 'FP32'
+
+                    # Under strict_format_check only: if the predecessor claimed a
+                    # specific (non-FP32) format, run a compliance check on the
+                    # captured incoming tensor to verify the claim matches reality.
+                    # Non-strict mode leaves the Input Check as ↪ PASS-THROUGH.
+                    input_check_str = passthrough_str
+                    if strict and flow_fmt != 'FP32' and name in self.quant_activations:
+                        captured = self.quant_activations[name]
+                        if isinstance(captured, torch.Tensor):
+                            res = _check_for_fmt(captured, flow_fmt)
+                            if res is not None:
+                                passed, cnt, examples = res
+                                input_check_str = format_status(passed, cnt, _CHECK_W, examples)
+
+                    na_fmt = f"{'N/A':<{_FMT_W}}"
+                    no_iq = f"{'No':<{_IQ_W}}"
+                    flow_cell = f"{flow_fmt:<{_FMT_W}}"
+                    report_lines.append(
+                        f"{name:<{_NAME_W}} | {layer_type:<{_TYPE_W}} | {shape_str:<{_SHAPE_W}} | "
+                        f"{na_fmt} | {no_iq} | {flow_cell} | {flow_cell} | {flow_cell} | "
+                        f"{passthrough_str} | {input_check_str}"
+                    )
+                    # Pass-through preserves the upstream fmt for subsequent passthroughs.
                     continue
 
                 # Determine whether to use table-based or mantissa-precision compliance
@@ -742,17 +844,35 @@ class LayerComparator:
                 unknown_fmt_str = f"{'N/A (Unknown fmt)':<{_CHECK_W}}"
                 weight_str = f"{'N/A':<{_CHECK_W}}"
 
+                # Per-tensor fmt strings for the display columns and strict checks.
+                weight_fmt, input_quantized, pre_quant_fmt, input_fmt, output_fmt = _fmt_strings(module)
+
                 def _compliance_check(tensor):
                     """Run the appropriate compliance check and return (passed, inv_count, examples)."""
                     if use_mant_check and mant_bits is not None:
                         return _check_mantissa_precision(tensor, mant_bits)
                     return check_fp8_compliance(tensor, valid_values)
 
+                def _check_input(tensor):
+                    if strict:
+                        res = _check_for_fmt(tensor, input_fmt)
+                        if res is not None:
+                            return res
+                    return _compliance_check(tensor)
+
+                def _check_output(tensor):
+                    if strict:
+                        res = _check_for_fmt(tensor, output_fmt)
+                        if res is not None:
+                            return res
+                    return _compliance_check(tensor)
+
                 if unknown_fmt:
                     weight_str = unknown_fmt_str
                 elif is_under_construction:
                      weight_str = under_construction_str
-                # 1. Weights (Main Table)
+                # 1. Weights (Main Table) — always use _compliance_check since
+                # weight_fmt == module.q_type by definition.
                 elif hasattr(module, 'weight_fp8') and module.weight_fp8 is not None:
                     passed, inv_count, examples = _compliance_check(module.weight_fp8.float())
                     weight_str = format_status(passed, inv_count, _CHECK_W, examples)
@@ -802,11 +922,11 @@ class LayerComparator:
                      input_str = f"{ORANGE}{_wpad(custom_status, _CHECK_W)}{RESET}"
                 # Prefer internal unscaled capture for Quant layers
                 elif hasattr(module, 'last_quant_input_unscaled') and module.last_quant_input_unscaled is not None:
-                    input_passed, i_inv_count, i_examples = _compliance_check(module.last_quant_input_unscaled)
+                    input_passed, i_inv_count, i_examples = _check_input(module.last_quant_input_unscaled)
                     input_str = format_status(input_passed, i_inv_count, _CHECK_W, i_examples)
                 # Check output for activation layers (they quantize output, not input)
                 elif hasattr(module, 'last_quant_output_unscaled') and module.last_quant_output_unscaled is not None:
-                    input_passed, i_inv_count, i_examples = _compliance_check(module.last_quant_output_unscaled)
+                    input_passed, i_inv_count, i_examples = _check_output(module.last_quant_output_unscaled)
                     input_str = format_status(input_passed, i_inv_count, _CHECK_W, i_examples)
                 # Fallback to hook capture
                 elif name in self.quant_activations:
@@ -829,7 +949,15 @@ class LayerComparator:
                     elif hasattr(module, 'last_quant_output_unscaled') and module.last_quant_output_unscaled is not None:
                          shape_str = str(tuple(module.last_quant_output_unscaled.shape[1:]))
 
-                report_lines.append(f"{name:<{_NAME_W}} | {layer_type:<{_TYPE_W}} | {shape_str:<{_SHAPE_W}} | {weight_str} | {input_str}")
+                report_lines.append(
+                    f"{name:<{_NAME_W}} | {layer_type:<{_TYPE_W}} | {shape_str:<{_SHAPE_W}} | "
+                    f"{weight_fmt:<{_FMT_W}} | {input_quantized:<{_IQ_W}} | {pre_quant_fmt:<{_FMT_W}} | "
+                    f"{input_fmt:<{_FMT_W}} | {output_fmt:<{_FMT_W}} | "
+                    f"{weight_str} | {input_str}"
+                )
+                # Remember this layer's output fmt so the next pass-through row
+                # can inherit it.
+                prev_output_fmt = output_fmt
         report_lines.append("-" * _SEP_W)
         report_lines.append("-" * _SEP_W)
         report_lines.append("\n")

--- a/runspace/src/eval/comparator.py
+++ b/runspace/src/eval/comparator.py
@@ -112,7 +112,7 @@ class LayerComparator:
                     self.quant_activations[name] = inp
             return hook
 
-        from src.ops.quant_base import QuantizedLayerMixin
+        from runspace.src.ops.quant_base import QuantizedLayerMixin
         from src.ops.quant_mha import DecomposedMultiheadAttention
 
         quantized_ops = tuple(OpRegistry.get_supported_ops().values())
@@ -253,7 +253,7 @@ class LayerComparator:
         """
         import torch.nn as nn
         import torch.nn.functional as F
-        from src.ops.quant_base import QuantizedLayerMixin
+        from runspace.src.ops.quant_base import QuantizedLayerMixin
         from src.ops.quant_mha import DecomposedMultiheadAttention
         
         report_lines = []
@@ -298,6 +298,9 @@ class LayerComparator:
                     module = self.quant_model.get_submodule(node.target)
                     if isinstance(module, quantized_ops):
                         quantized_nodes.append(f"{node.name} ({module.__class__.__name__})")
+                    elif OpRegistry.is_passthrough(module.__class__.__name__):
+                        # Non-quantized pass-through op (e.g. ObservedSimpleNMS); out of scope for coverage.
+                        continue
                     elif isinstance(module, supported_modules):
                         unquantized_supported_nodes.append(f"{node.name} ({module.__class__.__name__})")
                     else:
@@ -349,9 +352,11 @@ class LayerComparator:
             for name, module in self.quant_model.named_modules():
                 # Check if leaf (no children) OR DecomposedMHA
                 if len(list(module.children())) == 0 or isinstance(module, DecomposedMultiheadAttention):
-                    
                     if isinstance(module, QuantizedLayerMixin) or isinstance(module, quantized_ops):
                         quantized_count += 1
+                    elif OpRegistry.is_passthrough(module.__class__.__name__):
+                        # Non-quantized pass-through op (e.g. ObservedSimpleNMS); out of scope for coverage.
+                        continue
                     elif isinstance(module, tuple(supported_layers.keys())):
                         unquantized_supported.append(f"{name} ({module.__class__.__name__})")
                     else:
@@ -386,7 +391,7 @@ class LayerComparator:
 
     def _compute_layer_metrics(self):
         from src.eval.metrics import compute_mse, compute_cosine_similarity
-        from src.ops.quant_base import QuantizedLayerMixin
+        from runspace.src.ops.quant_base import QuantizedLayerMixin
         from src.eval.compression import calculate_compression_stats
         
         # Track previous module type for fusion heuristic
@@ -533,7 +538,7 @@ class LayerComparator:
         print("Generating evaluation report... (this might take a moment)")
         from src.eval.metrics import compute_mse, compute_cosine_similarity, compute_min_max, check_fp8_compliance
         from src.quantization.quantizer import get_fp8_e4m3_table, get_fp8_e5m2_table
-        from src.ops.quant_base import QuantizedLayerMixin
+        from runspace.src.ops.quant_base import QuantizedLayerMixin
         from src.ops.quant_mha import DecomposedMultiheadAttention
         import os
         import torch.nn as nn
@@ -597,6 +602,7 @@ class LayerComparator:
         GREEN = "\033[92m"
         RED = "\033[91m"
         ORANGE = "\033[33m"
+        BLUE = "\033[94m"
         RESET = "\033[0m"
 
         def _wpad(s, width):
@@ -676,15 +682,28 @@ class LayerComparator:
         # If it's a GraphModule, use graph nodes to get topological order
         import torch.fx
         modules_to_process = []
-        
+
         if isinstance(self.quant_model, torch.fx.GraphModule):
             for node in self.quant_model.graph.nodes:
                 if node.op == 'call_module':
                     module = self.quant_model.get_submodule(node.target)
                     modules_to_process.append((node.target, module))
         else:
-            # Fallback to named_modules()
-            modules_to_process = list(self.quant_model.named_modules())
+            # Forward hooks populate self.quant_activations in execution order,
+            # so its keys give the true forward-call order for every leaf that ran.
+            # Fall back to named_modules() for any leaf that never fired so the
+            # table still lists them.
+            seen = set()
+            for name in self.quant_activations.keys():
+                try:
+                    module = self.quant_model.get_submodule(name)
+                except AttributeError:
+                    continue
+                modules_to_process.append((name, module))
+                seen.add(name)
+            for name, module in self.quant_model.named_modules():
+                if name not in seen:
+                    modules_to_process.append((name, module))
 
         for name, module in modules_to_process:
             # Check leaf modules or DecomposedMHA
@@ -702,6 +721,17 @@ class LayerComparator:
                 # Check for Under Construction Status
                 is_under_construction = OpRegistry.is_under_construction(layer_type)
                 under_construction_str = f"{RED}{_wpad('🚧 UNDER CONSTRUCTION', _CHECK_W)}{RESET}"
+
+                # Pass-through ops forward to the next quantized layer and own
+                # neither weight nor activation quantization. Short-circuit the
+                # row with a distinct tag; skip all compliance checks.
+                if OpRegistry.is_passthrough(layer_type):
+                    passthrough_str = f"{BLUE}{_wpad('↪ PASS-THROUGH', _CHECK_W)}{RESET}"
+                    shape_str = "N/A"
+                    if name in self.ref_activations:
+                        shape_str = str(tuple(self.ref_activations[name].shape[1:]))
+                    report_lines.append(f"{name:<{_NAME_W}} | {layer_type:<{_TYPE_W}} | {shape_str:<{_SHAPE_W}} | {passthrough_str} | {passthrough_str}")
+                    continue
 
                 # Determine whether to use table-based or mantissa-precision compliance
                 use_mant_check = q_type not in _NATIVE_FORMATS

--- a/runspace/src/eval/metrics/matching.py
+++ b/runspace/src/eval/metrics/matching.py
@@ -64,7 +64,7 @@ def _pose_auc(errors: list[float], thresholds: list[int]) -> list[float]:
     _trapz = getattr(np, 'trapezoid', None) or np.trapz
     aucs = []
     for thr in thresholds:
-        last = np.searchsorted(errors_ext, thr, side='right')
+        last = np.searchsorted(errors_ext, thr)
         e = np.concatenate([errors_ext[:last], [float(thr)]])
         r = np.concatenate([recall_ext[:last], [recall_ext[last - 1]]])
         aucs.append(float(_trapz(r, e) / thr))
@@ -80,7 +80,7 @@ def _estimate_pose(kpts0: np.ndarray, kpts1: np.ndarray,
         return None
     if len(kpts0) < 5:
         return None
-    f_mean = np.mean([K0[0, 0], K1[1, 1], K0[1, 1], K1[0, 0]])
+    f_mean = np.mean([K0[0, 0], K1[1, 1], K0[0, 0], K1[1, 1]])
     norm_thresh = thresh / f_mean
     kpts0n = (kpts0 - K0[[0, 1], [2, 2]][None]) / K0[[0, 1], [0, 1]][None]
     kpts1n = (kpts1 - K1[[0, 1], [2, 2]][None]) / K1[[0, 1], [0, 1]][None]
@@ -197,7 +197,7 @@ class MatchingMetrics:
                 self._sum_match_certainty += float(sc0[valid].mean())
                 self._pairs_with_matches += 1
 
-            if len(kp0) > 0:
+            if not has_gt and len(kp0) > 0:
                 self._sum_matching_score += num_matches / len(kp0)
 
             if has_gt and num_matches > 0:
@@ -210,6 +210,8 @@ class MatchingMetrics:
                 precision = float(correct.mean()) if len(correct) > 0 else 0.0
                 num_correct = int(correct.sum())
                 self._sum_precision += precision
+                if len(kp0) > 0:
+                    self._sum_matching_score += num_correct / len(kp0)
 
                 # Repeatability: fraction of kp0 whose nearest kp1 under the GT
                 # epipolar geometry is within EPIPOLAR_THRESH Sampson distance.

--- a/runspace/src/ops/observed_ops.py
+++ b/runspace/src/ops/observed_ops.py
@@ -200,9 +200,7 @@ class ObservedConcat(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        # Default True because these ops are not touched by the adapter's class-swap path
-        # (no original_cls registered), so nothing else flips this to True downstream.
-        self.input_quantization = True
+        self.input_quantization = False
 
     def forward(self, *tensors):
         if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
@@ -220,9 +218,7 @@ class ObservedAdd(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        # Default True because these ops are not touched by the adapter's class-swap path
-        # (no original_cls registered), so nothing else flips this to True downstream.
-        self.input_quantization = True
+        self.input_quantization = False
 
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         q1 = self.quantize_input(x)
@@ -244,9 +240,7 @@ class ObservedAttentionScores(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        # Default True because these ops are not touched by the adapter's class-swap path
-        # (no original_cls registered), so nothing else flips this to True downstream.
-        self.input_quantization = True
+        self.input_quantization = False
 
     def forward(self, query: torch.Tensor, key: torch.Tensor) -> torch.Tensor:
         q = self.quantize_input(query)
@@ -267,9 +261,7 @@ class ObservedAttentionApply(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        # Default True because these ops are not touched by the adapter's class-swap path
-        # (no original_cls registered), so nothing else flips this to True downstream.
-        self.input_quantization = True
+        self.input_quantization = False
 
     def forward(self, prob: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
         p = self.quantize_input(prob)
@@ -290,9 +282,7 @@ class ObservedDescMatmul(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        # Default True because these ops are not touched by the adapter's class-swap path
-        # (no original_cls registered), so nothing else flips this to True downstream.
-        self.input_quantization = True
+        self.input_quantization = False
 
     def forward(self, mdesc0: torch.Tensor, mdesc1: torch.Tensor) -> torch.Tensor:
         q0 = self.quantize_input(mdesc0)

--- a/runspace/src/ops/observed_ops.py
+++ b/runspace/src/ops/observed_ops.py
@@ -200,7 +200,9 @@ class ObservedConcat(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        self.input_quantization = False
+        # Default True because these ops are not touched by the adapter's class-swap path
+        # (no original_cls registered), so nothing else flips this to True downstream.
+        self.input_quantization = True
 
     def forward(self, *tensors):
         if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
@@ -218,7 +220,9 @@ class ObservedAdd(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        self.input_quantization = False
+        # Default True because these ops are not touched by the adapter's class-swap path
+        # (no original_cls registered), so nothing else flips this to True downstream.
+        self.input_quantization = True
 
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         q1 = self.quantize_input(x)
@@ -240,7 +244,9 @@ class ObservedAttentionScores(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        self.input_quantization = False
+        # Default True because these ops are not touched by the adapter's class-swap path
+        # (no original_cls registered), so nothing else flips this to True downstream.
+        self.input_quantization = True
 
     def forward(self, query: torch.Tensor, key: torch.Tensor) -> torch.Tensor:
         q = self.quantize_input(query)
@@ -261,7 +267,9 @@ class ObservedAttentionApply(nn.Module, QuantizedLayerMixin):
         self.quantization_bias = quantization_bias
         self.quant_mode = quant_mode
         self.chunk_size = chunk_size
-        self.input_quantization = False
+        # Default True because these ops are not touched by the adapter's class-swap path
+        # (no original_cls registered), so nothing else flips this to True downstream.
+        self.input_quantization = True
 
     def forward(self, prob: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
         p = self.quantize_input(prob)
@@ -269,15 +277,27 @@ class ObservedAttentionApply(nn.Module, QuantizedLayerMixin):
         return torch.einsum('bhnm,bdhm->bdhn', p, v)
 
 
-@OpRegistry.register("ObservedDescMatmul", under_construction=True)
-class ObservedDescMatmul(nn.Module):
-    """Descriptor similarity matmul: einsum + scale by sqrt(dim)."""
-    def __init__(self, descriptor_dim: int):
+@OpRegistry.register("ObservedDescMatmul", is_activation=False)
+class ObservedDescMatmul(nn.Module, QuantizedLayerMixin):
+    """Descriptor similarity einsum (desc0 · desc1ᵀ / √d).
+
+    Quantizes both operands to FP8 before the einsum, mirroring QuantMatMul.
+    """
+    def __init__(self, descriptor_dim: int, q_type="fp8_e4m3", quantization_bias: int = None, quant_mode="tensor", chunk_size=None):
         super().__init__()
         self.scale = descriptor_dim ** 0.5
+        self.q_type = q_type
+        self.quantization_bias = quantization_bias
+        self.quant_mode = quant_mode
+        self.chunk_size = chunk_size
+        # Default True because these ops are not touched by the adapter's class-swap path
+        # (no original_cls registered), so nothing else flips this to True downstream.
+        self.input_quantization = True
 
     def forward(self, mdesc0: torch.Tensor, mdesc1: torch.Tensor) -> torch.Tensor:
-        return torch.einsum('bdn,bdm->bnm', mdesc0, mdesc1) / self.scale
+        q0 = self.quantize_input(mdesc0)
+        q1 = self.quantize_input(mdesc1)
+        return torch.einsum('bdn,bdm->bnm', q0, q1) / self.scale
 
 
 # --- FP32-required op --------------------------------------------------------

--- a/runspace/src/ops/observed_ops.py
+++ b/runspace/src/ops/observed_ops.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from ..registry.op_registry import OpRegistry
+from .quant_base import QuantizedLayerMixin
 
 
 def _simple_nms(scores, nms_radius: int):
@@ -40,14 +41,14 @@ def _top_k_keypoints(keypoints, scores, k: int):
 # Passthrough / linear ops — like ReLU, value representation unchanged
 # ---------------------------------------------------------------------------
 
-@OpRegistry.register("ObservedDiscardTrash", compliance_status="FP32 activation")
+@OpRegistry.register("ObservedDiscardTrash", passthrough=True)
 class ObservedDiscardTrash(nn.Module):
     """Drop the dustbin (last) score channel (stageB3)."""
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x[:, :-1]
 
 
-@OpRegistry.register("ObservedReorderReshape", compliance_status="FP32 activation")
+@OpRegistry.register("ObservedReorderReshape", passthrough=True)
 class ObservedReorderReshape(nn.Module):
     """Pixel-shuffle reorder/reshape (stageB4-B7): (B,64,H/8,W/8) -> (B,H,W)."""
     def forward(self, scores: torch.Tensor) -> torch.Tensor:
@@ -69,7 +70,7 @@ class ObservedThreshold(nn.Module):
         return keypoints, score_list
 
 
-@OpRegistry.register("ObservedRemoveBorders", compliance_status="FP32 activation")
+@OpRegistry.register("ObservedRemoveBorders", passthrough=True)
 class ObservedRemoveBorders(nn.Module):
     """Remove keypoints too close to image borders (stageB9)."""
     def __init__(self, border: int = 4):
@@ -82,7 +83,7 @@ class ObservedRemoveBorders(nn.Module):
         return list(zip(*result))
 
 
-@OpRegistry.register("ObservedTopKKeypoints", compliance_status="FP32 activation")
+@OpRegistry.register("ObservedTopKKeypoints", passthrough=True)
 class ObservedTopKKeypoints(nn.Module):
     """Keep only the top-k highest-scoring keypoints (stageB13)."""
     def __init__(self, max_keypoints: int = -1):
@@ -97,7 +98,7 @@ class ObservedTopKKeypoints(nn.Module):
         return list(zip(*result))
 
 
-@OpRegistry.register("ObservedKeypointFlip", compliance_status="FP32 activation")
+@OpRegistry.register("ObservedKeypointFlip", passthrough=True)
 class ObservedKeypointFlip(nn.Module):
     """Convert keypoint coords from (row, col) to (x, y) order (stageB14)."""
     def forward(self, keypoints):
@@ -115,7 +116,7 @@ class ObservedL2Norm(nn.Module):
 # NMS — max-selection like MaxPool, no arithmetic (UNDER CONSTRUCTION)
 # ---------------------------------------------------------------------------
 
-@OpRegistry.register("ObservedSimpleNMS", under_construction=True)
+@OpRegistry.register("ObservedSimpleNMS", passthrough=True)
 class ObservedSimpleNMS(nn.Module):
     """NMS via repeated max_pool2d (stageB8). Pure max-selection — no arithmetic."""
     def __init__(self, radius: int = 4):
@@ -189,41 +190,83 @@ class ObservedKeypointNormalize(nn.Module):
         return (kpts - center[:, None, :]) / scaling[:, None, :]
 
 
-@OpRegistry.register("ObservedConcat", compliance_status="FP32 activation")
-class ObservedConcat(nn.Module):
-    """torch.cat wrapped as a module."""
-    def __init__(self, dim: int = 1):
+@OpRegistry.register("ObservedConcat", is_activation=False)
+class ObservedConcat(nn.Module, QuantizedLayerMixin):
+    """torch.cat wrapped as a module; quantizes each operand (mirrors QuantCat)."""
+    def __init__(self, dim: int = 1, q_type="fp8_e4m3", quantization_bias: int = None, quant_mode="tensor", chunk_size=None):
         super().__init__()
         self.dim = dim
+        self.q_type = q_type
+        self.quantization_bias = quantization_bias
+        self.quant_mode = quant_mode
+        self.chunk_size = chunk_size
+        self.input_quantization = False
 
     def forward(self, *tensors):
         if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
-            return torch.cat(tensors[0], dim=self.dim)
-        return torch.cat(tensors, dim=self.dim)
+            tensors = tensors[0]
+        quantized = [self.quantize_input(t) for t in tensors]
+        return torch.cat(quantized, dim=self.dim)
 
 
-@OpRegistry.register("ObservedAdd", compliance_status="FP32 activation")
-class ObservedAdd(nn.Module):
-    """Element-wise add (residual connections)."""
+@OpRegistry.register("ObservedAdd", is_activation=False)
+class ObservedAdd(nn.Module, QuantizedLayerMixin):
+    """Element-wise add (residual connections); quantizes each operand (mirrors QuantAdd)."""
+    def __init__(self, q_type="fp8_e4m3", quantization_bias: int = None, quant_mode="tensor", chunk_size=None):
+        super().__init__()
+        self.q_type = q_type
+        self.quantization_bias = quantization_bias
+        self.quant_mode = quant_mode
+        self.chunk_size = chunk_size
+        self.input_quantization = False
+
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        return x + y
+        q1 = self.quantize_input(x)
+        q2 = self.quantize_input(y)
+        return torch.add(q1, q2)
 
 
 # --- Attention matmul / similarity ops --------------------------------------
 
-@OpRegistry.register("ObservedAttentionScores", under_construction=True)
-class ObservedAttentionScores(nn.Module):
-    """Q·K^T scaled-dot-product (multi-head einsum + scale)."""
+@OpRegistry.register("ObservedAttentionScores", is_activation=False)
+class ObservedAttentionScores(nn.Module, QuantizedLayerMixin):
+    """Q·K^T scaled-dot-product (multi-head einsum + √d post-scale).
+
+    Quantizes both operands to FP8 before the einsum, mirroring QuantMatMul.
+    """
+    def __init__(self, q_type="fp8_e4m3", quantization_bias: int = None, quant_mode="tensor", chunk_size=None):
+        super().__init__()
+        self.q_type = q_type
+        self.quantization_bias = quantization_bias
+        self.quant_mode = quant_mode
+        self.chunk_size = chunk_size
+        self.input_quantization = False
+
     def forward(self, query: torch.Tensor, key: torch.Tensor) -> torch.Tensor:
-        dim = query.shape[1]
-        return torch.einsum('bdhn,bdhm->bhnm', query, key) / dim**0.5
+        q = self.quantize_input(query)
+        k = self.quantize_input(key)
+        dim = q.shape[1]
+        return torch.einsum('bdhn,bdhm->bhnm', q, k) / dim**0.5
 
 
-@OpRegistry.register("ObservedAttentionApply", under_construction=True)
-class ObservedAttentionApply(nn.Module):
-    """Score·V einsum (multi-head)."""
+@OpRegistry.register("ObservedAttentionApply", is_activation=False)
+class ObservedAttentionApply(nn.Module, QuantizedLayerMixin):
+    """Score·V einsum (multi-head).
+
+    Quantizes both operands to FP8 before the einsum, mirroring QuantMatMul.
+    """
+    def __init__(self, q_type="fp8_e4m3", quantization_bias: int = None, quant_mode="tensor", chunk_size=None):
+        super().__init__()
+        self.q_type = q_type
+        self.quantization_bias = quantization_bias
+        self.quant_mode = quant_mode
+        self.chunk_size = chunk_size
+        self.input_quantization = False
+
     def forward(self, prob: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
-        return torch.einsum('bhnm,bdhm->bdhn', prob, value)
+        p = self.quantize_input(prob)
+        v = self.quantize_input(value)
+        return torch.einsum('bhnm,bdhm->bdhn', p, v)
 
 
 @OpRegistry.register("ObservedDescMatmul", under_construction=True)

--- a/runspace/src/ops/quant_activations.py
+++ b/runspace/src/ops/quant_activations.py
@@ -117,7 +117,7 @@ class LUTActivation:
         return output, q_output
 
 
-@OpRegistry.register("QuantReLU", original_cls=nn.ReLU, is_activation=True, compliance_status="FP32 activation")
+@OpRegistry.register("QuantReLU", original_cls=nn.ReLU, is_activation=True, passthrough=True)
 class QuantReLU(nn.ReLU):
     """
     Quantized ReLU using LUT.

--- a/runspace/src/ops/quant_pooling.py
+++ b/runspace/src/ops/quant_pooling.py
@@ -4,7 +4,7 @@ from ..registry.op_registry import OpRegistry
 from .quant_base import QuantizedLayerMixin
 
 
-@OpRegistry.register("QuantMaxPool2d", original_cls=nn.MaxPool2d , under_construction=True)
+@OpRegistry.register("QuantMaxPool2d", original_cls=nn.MaxPool2d, passthrough=True)
 class QuantMaxPool2d(nn.MaxPool2d, QuantizedLayerMixin):
     """
     Quantized MaxPool2d layer.

--- a/runspace/src/quantization/quantizer.py
+++ b/runspace/src/quantization/quantizer.py
@@ -963,82 +963,32 @@ def check_fp8_compliance(tensor: torch.Tensor, valid_table: torch.Tensor = None,
              return False, count, examples
         return True, 0, []
 
-    # For FP8/FP4/FP*, we need the table
-    if valid_table is None:
-        if q_type == "fp8_e4m3":
-            valid_table = _generate_fp8_e4m3_table(tensor.device, bias=bias if bias is not None else 7)
-        elif q_type == "fp8_e5m2":
-            valid_table = _generate_fp8_e5m2_table(tensor.device, bias=bias if bias is not None else 15)
-        elif (q_type.startswith("fp") or q_type.startswith("ufp") or q_type.startswith("efp") or q_type.startswith("uefp")) and "_e" in q_type and "m" in q_type:
-             # Generic FP generation
-             try:
-                 is_efp = "efp" in q_type
-                 if is_efp:
-                     is_signed = q_type.startswith("efp")
-                 else:
-                     is_signed = q_type.startswith("fp")
-                 
-                 fpx_part = q_type.split('_')[0]
-                 e_part = q_type.split('_e')[1]
-                 exp_bits = int(e_part.split('m')[0])
-                 mant_bits = int(e_part.split('m')[1])
-                 
-                 # Calculate stored bits
-                 total_iter_bits = exp_bits + mant_bits
-                 if is_signed:
-                     total_iter_bits += 1
-                     
-                 # Calculate default bias if not provided
-                 if bias is None:
-                     bias = (1 << (exp_bits - 1)) - 1 if exp_bits > 0 else 0
-                 
-                 if is_efp:
-                     valid_table = _generate_efp_generic_table(tensor.device, total_iter_bits, exp_bits, mant_bits, bias, signed=is_signed)
-                 else:
-                     valid_table = _generate_fp_generic_table(tensor.device, total_iter_bits, exp_bits, mant_bits, bias, signed=is_signed)
-             except:
-                  raise ValueError(f"Could not parse or generate table for format {q_type}")
-        else:
-             raise ValueError(f"Unknown q_type: {q_type}")
-
-    valid_non_nan = valid_table[~torch.isnan(valid_table)]
+    # For FP formats: a value is valid iff it is a fixed point of the kernel —
+    # i.e., running quantize() on it yields itself. This ties the checker to the
+    # same simulator that produces activations/weights at runtime, so the valid
+    # set is exactly what the kernel can emit (not the mathematically-complete
+    # FP grid, which includes subnormal/exponent states the kernel doesn't
+    # synthesize).
     tensor_flat = tensor.contiguous().view(-1)
-    non_nan_vals = tensor_flat[~torch.isnan(tensor_flat)]
-    
-    if len(non_nan_vals) == 0:
+    finite_mask = torch.isfinite(tensor_flat)
+    finite_vals = tensor_flat[finite_mask]
+    if finite_vals.numel() == 0:
         return True, 0, []
-        
-    # Chunking to avoid OOM
-    # With N=1M and M=256 (FP8), matrix is 1M * 256 * 4 bytes = 1GB.
-    # This is fine for 1 config, but in parallel setup, multiple processes/threads might stress it?
-    # No, this runs sequentially in main process usually.
-    # However, for broader compatibility and speed, let's reduce chunk size purely for safety.
-    chunk_size = 10000 
-    num_chunks = (len(non_nan_vals) + chunk_size - 1) // chunk_size
-    
-    total_invalid = 0
-    examples = []
-    
-    for i in range(num_chunks):
-        chunk = non_nan_vals[i*chunk_size : (i+1)*chunk_size]
-        
-        # Broadcasting [Chunk, 1] - [1, Table] -> [Chunk, Table]
-        # Memory: Chunk * TableSize * 4 bytes
-        # 10k * 256 * 4 = 10MB. Very safe.
-        diffs = torch.abs(chunk.unsqueeze(1) - valid_non_nan.unsqueeze(0))
-        min_diffs = diffs.min(dim=1).values
-        
-        invalid_mask = min_diffs > rtol * torch.abs(chunk).clamp(min=1e-10)
-        
-        if invalid_mask.any():
-            count = invalid_mask.sum().item()
-            total_invalid += count
-            if len(examples) < 5:
-                examples.extend(chunk[invalid_mask][:5 - len(examples)].tolist())
+
+    # `quantize` dispatches on q_type and ends up in quantize_fp_generic for
+    # FP formats. We compute what the kernel would produce for each value and
+    # compare.
+    expected = quantize(finite_vals, q_type=q_type, rounding="nearest")
+    diff = (finite_vals - expected).abs()
+    tol = rtol * finite_vals.abs().clamp(min=1e-10)
+    invalid_mask = diff > tol
+
+    total_invalid = int(invalid_mask.sum().item())
+    examples = finite_vals[invalid_mask][:5].tolist() if total_invalid > 0 else []
 
     if total_invalid > 0:
         return False, total_invalid, examples
-        
+
     return True, 0, []
 
 def assert_fp8_valid(tensor: torch.Tensor, rtol: float = 1e-5, q_type: str = "fp8_e4m3", bias: int = None) -> None:

--- a/runspace/src/registry/op_registry.py
+++ b/runspace/src/registry/op_registry.py
@@ -10,9 +10,10 @@ class OpRegistry:
     _compliance_status = {} # Mapping from op_name -> status message (if custom)
     _supported_functions = set() # Set of supported functional operations (e.g. F.conv2d)
     _under_construction_ops = set() # Set of ops marked as under construction
+    _passthrough_ops = set() # Ops that forward to the next quantized layer without W/A quant of their own
 
     @classmethod
-    def register(cls, op_name: str, original_cls=None, is_activation=False, compliance_status=None, under_construction=False):
+    def register(cls, op_name: str, original_cls=None, is_activation=False, compliance_status=None, under_construction=False, passthrough=False):
         def decorator(cls_impl):
             # print(f"DEBUG: Registering {op_name} (original={original_cls}) in OpRegistry {id(cls)}")
             cls._registry[op_name] = cls_impl
@@ -24,6 +25,8 @@ class OpRegistry:
                 cls._compliance_status[op_name] = compliance_status
             if under_construction:
                 cls._under_construction_ops.add(op_name)
+            if passthrough:
+                cls._passthrough_ops.add(op_name)
             return cls_impl
         return decorator
 
@@ -72,6 +75,11 @@ class OpRegistry:
     def is_under_construction(cls, op_name: str):
         """Checks if the given op is marked as under construction."""
         return op_name in cls._under_construction_ops
+
+    @classmethod
+    def is_passthrough(cls, op_name: str):
+        """Checks if the given op is a pass-through (no W/A quant of its own)."""
+        return op_name in cls._passthrough_ops
 
 # Populate standard supported functions
 import torch

--- a/runspace/src/utils/feature_matching_viz.py
+++ b/runspace/src/utils/feature_matching_viz.py
@@ -86,15 +86,15 @@ def _info_header(quant_info, batch_metrics):
 
 
 def _add_info_box(fig, text):
-    """Add a styled text box below the suptitle."""
+    """Add a styled info box below the figure (bbox_inches='tight' will include it)."""
     if not text:
         return
     fig.text(
-        0.5, 0.995, text,
+        0.5, -0.005, text,
         ha='center', va='top',
-        fontsize=8.5,
+        fontsize=9,
         family='monospace',
-        bbox=dict(boxstyle='round,pad=0.4', facecolor='#1e1e2e', edgecolor='#444', alpha=0.88),
+        bbox=dict(boxstyle='round,pad=0.5', facecolor='#1e1e2e', edgecolor='#444', alpha=0.92),
         color='#cdd6f4',
         transform=fig.transFigure,
     )
@@ -155,7 +155,7 @@ def save_matching_viz(batch, ref_outputs, quant_outputs, output_path,
     )
     _draw_matches_on_ax(
         axes[1], img0, img1, q_kpts0, q_kpts1, q_mkpts0, q_mkpts1,
-        line_color='royalblue', kpt_color='royalblue',
+        line_color='deepskyblue', kpt_color='deepskyblue',
         title=f"Quantized  |  {len(q_mkpts0)} matches  "
               f"({len(q_kpts0)} / {len(q_kpts1)} kpts){q_prec_str}",
     )
@@ -170,7 +170,7 @@ def save_matching_viz(batch, ref_outputs, quant_outputs, output_path,
     for (x0, y0), (x1, y1) in zip(ref_mkpts0, ref_mkpts1):
         axes[2].plot([x0, x1 + W], [y0, y1], color='lime', linewidth=0.7, alpha=0.55)
     for (x0, y0), (x1, y1) in zip(q_mkpts0, q_mkpts1):
-        axes[2].plot([x0, x1 + W], [y0, y1], color='royalblue', linewidth=0.7, alpha=0.55)
+        axes[2].plot([x0, x1 + W], [y0, y1], color='deepskyblue', linewidth=0.7, alpha=0.55)
 
     label = pair_id if pair_id else "unknown"
     fig.suptitle(f"Match Comparison — {label}", fontsize=11, y=1.0)
@@ -219,7 +219,7 @@ def save_superglue_keypoints_viz(batch, ref_outputs, quant_outputs, output_path,
 
         for col, (kpts, color, title) in enumerate([
             (ref_kpts, 'lime',      f"{lbl} — Reference  |  {len(ref_kpts)} kpts"),
-            (q_kpts,   'royalblue', f"{lbl} — Quantized  |  {len(q_kpts)} kpts  "
+            (q_kpts,   'deepskyblue', f"{lbl} — Quantized  |  {len(q_kpts)} kpts  "
                                     f"(Δ {len(q_kpts)-len(ref_kpts):+d})"),
         ]):
             ax = axes[row, col]
@@ -241,7 +241,7 @@ def save_superglue_keypoints_viz(batch, ref_outputs, quant_outputs, output_path,
             ax.scatter(pts_ref_only[:, 0], pts_ref_only[:, 1], c='lime', s=5,
                        linewidths=0, label=f'Ref only ({len(pts_ref_only)})')
         if len(pts_q_only):
-            ax.scatter(pts_q_only[:, 0], pts_q_only[:, 1], c='royalblue', s=5,
+            ax.scatter(pts_q_only[:, 0], pts_q_only[:, 1], c='deepskyblue', s=5,
                        linewidths=0, label=f'Quant only ({len(pts_q_only)})')
         ax.legend(fontsize=7, markerscale=2, loc='upper right')
         ax.set_title(
@@ -297,7 +297,7 @@ def save_keypoints_viz(batch, ref_outputs, quant_outputs, output_path,
     for ax, kpts, color, title in [
         (axes[0], ref_kpts, 'lime',
          f"Reference  |  {len(ref_kpts)} keypoints"),
-        (axes[1], q_kpts, 'royalblue',
+        (axes[1], q_kpts, 'deepskyblue',
          f"Quantized  |  {len(q_kpts)} keypoints  (Δ {len(q_kpts)-len(ref_kpts):+d})"),
     ]:
         ax.imshow(img)
@@ -314,7 +314,7 @@ def save_keypoints_viz(batch, ref_outputs, quant_outputs, output_path,
         axes[2].scatter(pts_ref_only[:, 0], pts_ref_only[:, 1], c='lime', s=5,
                         linewidths=0, label=f'Ref only ({len(pts_ref_only)})')
     if len(pts_q_only):
-        axes[2].scatter(pts_q_only[:, 0], pts_q_only[:, 1], c='royalblue', s=5,
+        axes[2].scatter(pts_q_only[:, 0], pts_q_only[:, 1], c='deepskyblue', s=5,
                         linewidths=0, label=f'Quant only ({len(pts_q_only)})')
     axes[2].legend(fontsize=8, markerscale=2, loc='upper right')
     axes[2].set_title(


### PR DESCRIPTION
This pull request introduces a set of scripts and configuration files to automate and streamline the process of downloading, extracting, and preparing ScanNet test data for benchmarking, specifically aligned with SuperGlue's paper evaluation protocol. The changes include Python and Bash utilities for selecting relevant scenes, downloading only the required `.sens` files, extracting only the referenced frames, and generating the correct pairs and scene lists. Additionally, there are updates to the Docker and Compose setup for improved compatibility and data mounting, and a new evaluation configuration is added.

The most important changes are:

**ScanNet Data Download and Extraction Automation:**

* Added `download-scannet.py`, a comprehensive script to download ScanNet public data releases, supporting selective downloads by scan ID, file type, and various dataset components.
* Added `download_paper_scenes.sh` and `download_scannet_test.sh` scripts to automate downloading only the `.sens` files for the specific test scenes referenced in SuperGlue's evaluation pairs, logging progress and supporting resumable downloads. [[1]](diffhunk://#diff-afba2c164de8e8ba184a38ab1a505cb46d07e0aac269b4cb0687526163819263R1-R46) [[2]](diffhunk://#diff-8961a74dd619e9c5bda74fbd544e8e10294e271458486b9bacac40b24b690cc3R1-R14)
* Added `extract.py` and `extract_paper_frames.sh` to extract only the JPEG color frames referenced in the evaluation pairs from the raw `.sens` files, minimizing storage and processing requirements. [[1]](diffhunk://#diff-15b5daaa0bb7790a95d77fd4d9d0a95ab7a6cbb57d35bacac18d569be32403c2R1-R57) [[2]](diffhunk://#diff-15984e695a19d223ae8f0700b37da0884b91d1d4fe6a48403a42e058632954d2R1-R46)

**Benchmark Pair and Scene List Preparation:**

* Added `make_paper_pairs.sh` to generate a filtered pairs file containing only pairs from the selected test scenes, maintaining the original order and format.
* Added `make_scene_list.py`, a utility to emit the ordered, deduplicated list of scenes referenced in the pairs file, with options to filter out already-downloaded scenes.

**Configuration and Infrastructure Updates:**

* Added `sg_only_scannet_paper.yaml`, a configuration file for running the SuperGlue benchmark on the ScanNet test pairs with quantization and evaluation settings matching the paper protocol.
* Updated `docker-compose.yml` to mount the ScanNet data directory as read-only, ensuring container access to the dataset.
* Changed the Dockerfile to use `opencv-python-headless` instead of `opencv-python` for better compatibility in headless environments.