### PR TITLE
Add CUDA kernels for FP8 encoding and decoding

### DIFF
--- a/runspace/src/ops/quant_base.py
+++ b/runspace/src/ops/quant_base.py
@@ -95,6 +95,23 @@ def quantize_tensor(
             'fp7_e6m0'
         ]
         
+        fp8candidates = [
+            'fp8_e4m3', 'fp8_e5m2', 'fp8_e3m4', 'fp8_e2m5', 'fp8_e1m6', 
+            'fp8_e6m1', 'fp8_e7m0',
+        ]
+        
+        if q_type in fp8candidates:
+            # CUDA-backed path (bit-exact mirror via _ARU_nf encoder).
+            from .quant_base_cuda import quantize_tensor_cuda
+            return quantize_tensor_cuda(
+                input, q_type=q_type, return_unscaled=return_unscaled,
+                return_scale=return_scale, mode=mode, chunk_size=chunk_size,
+                rounding=rounding, validate=validate, chunk_formats=chunk_formats,
+            )
+
+        else:
+            print(f"cuda not used.")
+
         # Flatten and chunk
         if input.dim() > 1:
             flat_input = input.flatten(1)

--- a/runspace/src/ops/quant_base_cuda.py
+++ b/runspace/src/ops/quant_base_cuda.py
@@ -1,0 +1,175 @@
+"""
+CUDA-backed drop-in replacement for `quant_base.quantize_tensor`.
+
+Uses the `encode_fp8_*_ARU_nf` device functions, which (post the
+fp8_codec.cuh subnormal fix) bit-exactly mirror Python `quantize_fp_generic`.
+The semantics for tensor / channel / chunk modes match `quantize_tensor`:
+
+  - Same `calculate_scale` (pow2_floor of clamped amax) for tensor/channel.
+  - Same dim-1-as-channel convention for `mode='channel'` (the CUDA channel
+    kernel's row-as-channel layout is sidestepped by pre-dividing on host
+    and calling `encode_fp8_tensor_ARU_nf` instead).
+  - Same chunk_size=128 power-of-two per-chunk scale for `mode='chunk'`.
+
+Not supported (raises NotImplementedError):
+  - `mode='dynamic_oracle'` and `q_type` starting with `'dynamic_oracle'`
+  - `chunk_formats` per-chunk format selection
+  - `chunk_size` other than 128
+
+`rounding` and `validate` are accepted for API parity but ignored — the
+encoder is fixed at ARU + no-flush.
+"""
+from __future__ import annotations
+
+import torch
+
+from ..quantization.constants import get_format_params, get_quantization_bias
+from ..quantization.cuda import (
+    encode_fp8_tensor_ARU_nf, decode_fp8_tensor,
+    encode_fp8_chunk_ARU_nf,  decode_fp8_chunk,
+)
+from .quant_base import calculate_scale
+
+
+CHUNK_SIZE = 128
+
+
+def _to_cuda_float32_contig(t: torch.Tensor) -> torch.Tensor:
+    if t.dtype != torch.float32:
+        t = t.float()
+    if not t.is_cuda:
+        t = t.cuda()
+    return t.contiguous()
+
+
+def _encode_decode_tensor(x_flat_cuda: torch.Tensor, scale_val: float,
+                          e: int, m: int, b: int) -> torch.Tensor:
+    """Run `encode_fp8_tensor_ARU_nf` + `decode_fp8_tensor` on a 1-D float32
+    CUDA tensor. Returns the dequantized 1-D CUDA tensor."""
+    N = x_flat_cuda.numel()
+    encoded = torch.empty(N, dtype=torch.uint8,   device='cuda')
+    decoded = torch.empty(N, dtype=torch.float32, device='cuda')
+    encode_fp8_tensor_ARU_nf(x_flat_cuda, encoded, scale_val, e, m, b)
+    decode_fp8_tensor(encoded, decoded, scale_val, e, m, b)
+    return decoded
+
+
+def quantize_tensor_cuda(
+    input: torch.Tensor,
+    q_type: str = 'fp8_e4m3',
+    return_unscaled: bool = False,
+    return_scale: bool = False,
+    mode: str = 'tensor',
+    chunk_size: int | None = None,
+    rounding: str = 'nearest',     # accepted for parity, ignored
+    validate: bool = False,        # accepted for parity, ignored
+    chunk_formats=None,
+):
+    """CUDA-backed `quantize_tensor`. See module docstring for caveats."""
+    if q_type == 'fp32':
+        max_val = input.abs().max()
+        scale = torch.tensor(1.0, device=input.device)
+        if return_unscaled and return_scale:
+            return input, input, max_val, scale, scale
+        if return_unscaled:
+            return input, input, max_val
+        if return_scale:
+            return input, scale, scale
+        return input, max_val
+
+    if q_type.startswith('dynamic_oracle') or mode == 'dynamic_oracle':
+        raise NotImplementedError("dynamic_oracle is not supported by quantize_tensor_cuda")
+    if chunk_formats is not None:
+        raise NotImplementedError("per-chunk `chunk_formats` is not supported by quantize_tensor_cuda")
+
+    e, m = get_format_params(q_type)
+    b    = get_quantization_bias(q_type)
+
+    # =============================================================
+    # chunk mode: kernel computes its own per-chunk pow2 scale
+    # =============================================================
+    if mode == 'chunk':
+        cs = chunk_size if chunk_size is not None else CHUNK_SIZE
+        if cs != CHUNK_SIZE:
+            raise NotImplementedError(
+                f"CUDA chunk kernel is hardcoded to chunk_size={CHUNK_SIZE}; got {cs}")
+
+        orig_shape = input.shape
+        if input.dim() > 1:
+            flat_input = input.flatten(1)            # [B, K]
+            batch_size = input.shape[0]
+        else:
+            flat_input = input.unsqueeze(0)          # [1, K]
+            batch_size = 1
+
+        num_elements = flat_input.shape[-1]
+        pad_len = (-num_elements) % cs
+        if pad_len:
+            flat_input = torch.nn.functional.pad(flat_input, (0, pad_len))
+
+        x_cuda = _to_cuda_float32_contig(flat_input.reshape(-1))
+        N = x_cuda.numel()
+        encoded = torch.empty(N,        dtype=torch.uint8,   device='cuda')
+        scales  = torch.empty(N // cs,  dtype=torch.float32, device='cuda')
+        decoded = torch.empty(N,        dtype=torch.float32, device='cuda')
+        encode_fp8_chunk_ARU_nf(x_cuda, encoded, scales, e, m, b, cs)
+        decode_fp8_chunk(encoded, scales, decoded, e, m, b, cs)
+
+        # Reshape, drop padding, restore original shape, return on input's device
+        decoded = decoded.view(batch_size, -1)
+        if pad_len:
+            decoded = decoded[:, :num_elements]
+        quantized = decoded.reshape(orig_shape).to(input.device)
+
+        # Build a broadcastable scale tensor (one scale per chunk, expanded
+        # to the original element layout). `s_packed` keeps the per-chunk vector.
+        s_packed = scales.view(batch_size, -1)       # [B, num_chunks]
+        s_expanded = (s_packed.unsqueeze(-1)
+                              .expand(-1, -1, cs)
+                              .reshape(batch_size, -1))
+        if pad_len:
+            s_expanded = s_expanded[:, :num_elements]
+        s = s_expanded.reshape(orig_shape).to(input.device)
+        s_packed = s_packed.to(input.device)
+
+        # Match `quantize_tensor` chunk path: max over per-chunk input amaxes
+        # (clamped to 1e-9). Equivalent to `input.abs().max()` for any
+        # non-trivial input.
+        max_val = input.abs().max().clamp(min=1e-9)
+        if return_unscaled and return_scale:
+            return quantized, quantized, max_val, s, s_packed
+        if return_unscaled:
+            return quantized, quantized, max_val
+        if return_scale:
+            return quantized, s, s_packed
+        return quantized, max_val
+
+    # =============================================================
+    # tensor / channel mode: host computes scale (pow2_floor of amax)
+    # =============================================================
+    if mode == 'channel':
+        if input.dim() >= 2:
+            reduce_dims = tuple(d for d in range(input.dim()) if d != 1)
+        else:
+            reduce_dims = tuple(range(input.dim()))
+    else:  # 'tensor'
+        reduce_dims = tuple(range(input.dim()))
+
+    max_val = input.abs().amax(dim=reduce_dims, keepdim=True).clamp(min=1e-5)
+    s = calculate_scale(max_val, q_type)             # broadcastable to input.shape
+
+    # Pre-divide on host so we can use the scalar-scale tensor encoder for
+    # both modes (sidesteps the channel kernel's row-as-channel convention).
+    input_scaled = input / s
+    x_cuda = _to_cuda_float32_contig(input_scaled.reshape(-1))
+    decoded_flat = _encode_decode_tensor(x_cuda, 1.0, e, m, b)
+    input_fp8_unscaled = decoded_flat.view(input.shape).to(input.device)
+    input_fp8 = input_fp8_unscaled * s
+
+    if return_unscaled:
+        if return_scale:
+            return input_fp8, input_fp8_unscaled, max_val, s, s
+        return input_fp8, input_fp8_unscaled, max_val
+    if return_scale:
+        return input_fp8, s, s
+    return input_fp8, max_val

--- a/runspace/src/quantization/cuda/__init__.py
+++ b/runspace/src/quantization/cuda/__init__.py
@@ -1,0 +1,44 @@
+# runspace/src/quantization/cuda/__init__.py
+"""JIT loader for QBench FP8 CUDA kernels."""
+
+import os
+from torch.utils.cpp_extension import load
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+_module = load(
+    name='qbench_fp8_cuda',
+    sources=[
+        os.path.join(_HERE, 'fp8_encode.cu'),
+        os.path.join(_HERE, 'fp8_decode.cu'),
+    ],
+    extra_cuda_cflags=['-O3', '-lineinfo'],
+    verbose=True,
+)
+
+# Per-chunk codec.
+encode_fp8_chunk = _module.encode_fp8_chunk
+decode_fp8_chunk = _module.decode_fp8_chunk
+
+# Per-tensor codec (scalar scale).
+encode_fp8_tensor    = _module.encode_fp8_tensor
+decode_fp8_tensor    = _module.decode_fp8_tensor
+
+# Per-channel codec (one scale per channel of [C, K] input).
+encode_fp8_channel   = _module.encode_fp8_channel
+decode_fp8_channel   = _module.decode_fp8_channel
+
+# ARU variants (Always Round Up — round-half-up, no sticky bit).
+encode_fp8_chunk_ARU    = _module.encode_fp8_chunk_ARU
+encode_fp8_tensor_ARU   = _module.encode_fp8_tensor_ARU
+encode_fp8_channel_ARU  = _module.encode_fp8_channel_ARU
+
+# nf variants (No subnormal Flush — RNTE rounding).
+encode_fp8_chunk_nf     = _module.encode_fp8_chunk_nf
+encode_fp8_tensor_nf    = _module.encode_fp8_tensor_nf
+encode_fp8_channel_nf   = _module.encode_fp8_channel_nf
+
+# ARU_nf variants (Always Round Up + No subnormal Flush).
+encode_fp8_chunk_ARU_nf    = _module.encode_fp8_chunk_ARU_nf
+encode_fp8_tensor_ARU_nf   = _module.encode_fp8_tensor_ARU_nf
+encode_fp8_channel_ARU_nf  = _module.encode_fp8_channel_ARU_nf

--- a/runspace/src/quantization/cuda/fp8_codec.cuh
+++ b/runspace/src/quantization/cuda/fp8_codec.cuh
@@ -1,0 +1,237 @@
+// runspace/src/quantization/cuda/fp8_codec.cuh
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+
+// ----------------------------------------------------------------------------
+// Helper A: pow2_floor_nonneg.
+// Returns 2^floor(log2(a)) for a > 0 by zeroing the FP32 mantissa.
+// For a == 0 returns 1.0f as a safe neutral scale.
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+float pow2_floor_nonneg(float a) {
+    if (a == 0.0f) return 1.0f;
+    uint32_t bits = __float_as_uint(a);
+    bits &= 0xFF800000u;
+    return __uint_as_float(bits);
+}
+
+
+// ----------------------------------------------------------------------------
+// Helper B: warp_amax. Butterfly reduction over all 32 lanes; result on every lane.
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+float warp_amax(float v) {
+    v = fabsf(v);
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) {
+        v = fmaxf(v, __shfl_xor_sync(0xFFFFFFFFu, v, o));
+    }
+    return v;
+}
+
+
+// ----------------------------------------------------------------------------
+// Helper C: encode_fp8. FP32 -> FP8(e, m, b) with RNTE and permissive saturation.
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+uint8_t encode_fp8(float y, int e, int m, int b) {
+    const uint32_t u    = __float_as_uint(y);
+    const uint32_t sign = (u >> 31) & 1u;
+    const uint32_t mag  = u & 0x7FFFFFFFu;
+
+    if (mag == 0u) return 0u;
+
+    const int32_t  exp_f  = int32_t((mag >> 23) & 0xFFu) - 127;
+    const uint32_t mant_f = mag & 0x7FFFFFu;
+    const int32_t  exp_t  = exp_f + b;
+
+    if (exp_t < 1) return uint8_t(sign << 7);                 // R6 simplified flush
+
+    const int      shift     = 23 - m;
+    const uint32_t round_bit = (mant_f >> (shift - 1)) & 1u;
+    const uint32_t sticky    = (mant_f & ((1u << (shift - 1)) - 1u)) ? 1u : 0u;
+    uint32_t       mant_t    = mant_f >> shift;
+    const uint32_t round_up  = round_bit & (sticky | (mant_t & 1u));
+    mant_t += round_up;
+
+    int32_t exp_out = exp_t;
+    if (mant_t == (1u << m)) {
+        mant_t  = 0u;
+        exp_out += 1;
+    }
+
+    // Permissive saturation: only clamp on actual overflow. exp_out == max_exp
+    // is a legal normal (matches QBench reference and OCP E4M3 permissive).
+    const int32_t max_exp = (1 << e) - 1;
+    if (exp_out > max_exp) {                                   // FIX: > not >=
+        exp_out = max_exp;
+        mant_t  = (1u << m) - 1u;
+    }
+
+    return uint8_t((sign << 7) | (uint32_t(exp_out) << m) | mant_t);
+}
+
+
+// ----------------------------------------------------------------------------
+// Helper C2: encode_fp8_ARU. Same as encode_fp8 but Always Rounds Up (no sticky).
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+uint8_t encode_fp8_ARU(float y, int e, int m, int b) {
+    const uint32_t u    = __float_as_uint(y);
+    const uint32_t sign = (u >> 31) & 1u;
+    const uint32_t mag  = u & 0x7FFFFFFFu;
+
+    if (mag == 0u) return 0u;
+
+    const int32_t  exp_f  = int32_t((mag >> 23) & 0xFFu) - 127;
+    const uint32_t mant_f = mag & 0x7FFFFFu;
+    const int32_t  exp_t  = exp_f + b;
+
+    if (exp_t < 1) return uint8_t(sign << 7);
+
+    const int      shift     = 23 - m;
+    const uint32_t round_bit = (mant_f >> (shift - 1)) & 1u;
+    uint32_t       mant_t    = mant_f >> shift;
+    mant_t += round_bit;                                        // ARU: no sticky
+
+    int32_t exp_out = exp_t;
+    if (mant_t == (1u << m)) {
+        mant_t  = 0u;
+        exp_out += 1;
+    }
+
+    const int32_t max_exp = (1 << e) - 1;
+    if (exp_out > max_exp) {
+        exp_out = max_exp;
+        mant_t  = (1u << m) - 1u;
+    }
+
+    return uint8_t((sign << 7) | (uint32_t(exp_out) << m) | mant_t);
+}
+
+
+// ----------------------------------------------------------------------------
+// Helper C3: encode_fp8_nf. Same as encode_fp8 (RNTE) but No subnormal Flush.
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+uint8_t encode_fp8_nf(float y, int e, int m, int b) {
+    const uint32_t u    = __float_as_uint(y);
+    const uint32_t sign = (u >> 31) & 1u;
+    const uint32_t mag  = u & 0x7FFFFFFFu;
+
+    if (mag == 0u) return 0u;
+
+    const int32_t  exp_f  = int32_t((mag >> 23) & 0xFFu) - 127;
+    const uint32_t mant_f = mag & 0x7FFFFFu;
+    const int32_t  exp_t  = exp_f + b;
+
+    // No flush guard: values with exp_t < 1 fall through the rounding path.
+
+    const int      shift     = 23 - m;
+    const uint32_t round_bit = (mant_f >> (shift - 1)) & 1u;
+    const uint32_t sticky    = (mant_f & ((1u << (shift - 1)) - 1u)) ? 1u : 0u;
+    uint32_t       mant_t    = mant_f >> shift;
+    const uint32_t round_up  = round_bit & (sticky | (mant_t & 1u));
+    mant_t += round_up;
+
+    int32_t exp_out = exp_t;
+    if (mant_t == (1u << m)) {
+        mant_t  = 0u;
+        exp_out += 1;
+    }
+
+    const int32_t max_exp = (1 << e) - 1;
+    if (exp_out > max_exp) {
+        exp_out = max_exp;
+        mant_t  = (1u << m) - 1u;
+    }
+
+    return uint8_t((sign << 7) | (uint32_t(exp_out) << m) | mant_t);
+}
+
+
+// ----------------------------------------------------------------------------
+// Helper C4: encode_fp8_ARU_nf. ARU rounding + No subnormal Flush.
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+uint8_t encode_fp8_ARU_nf(float y, int e, int m, int b) {
+    const uint32_t u    = __float_as_uint(y);
+    const uint32_t sign = (u >> 31) & 1u;
+    const uint32_t mag  = u & 0x7FFFFFFFu;
+
+    if (mag == 0u) return 0u;
+
+    const int32_t  exp_f  = int32_t((mag >> 23) & 0xFFu) - 127;
+    const uint32_t mant_f = mag & 0x7FFFFFu;
+    const int32_t  exp_t  = exp_f + b;
+
+    // Subnormal path: encode as IEEE-style subnormal byte (exp_field=0).
+    // Mirrors `quantize_fp_generic` (round-half-up, no sticky).
+    if (exp_t < 1) {
+        const uint32_t mant_with_lead = (1u << 23) | mant_f;
+        const int      shift_sub      = 24 - b - m - exp_f;
+        uint32_t mant_sub = 0u;
+        int32_t  exp_sub  = 0;
+
+        if (shift_sub >= 25) {
+            mant_sub = 0u;                          // deep underflow
+        } else if (shift_sub == 24) {
+            mant_sub = 1u;                          // implicit 1 acts as round bit
+        } else {
+            const uint32_t round_bit = (mant_with_lead >> (shift_sub - 1)) & 1u;
+            mant_sub = mant_with_lead >> shift_sub;
+            mant_sub += round_bit;
+        }
+
+        if (mant_sub == (1u << m)) {                // carry to smallest normal
+            mant_sub = 0u;
+            exp_sub  = 1;
+        }
+        return uint8_t((sign << 7) | (uint32_t(exp_sub) << m) | uint8_t(mant_sub));
+    }
+
+    const int      shift     = 23 - m;
+    const uint32_t round_bit = (mant_f >> (shift - 1)) & 1u;
+    uint32_t       mant_t    = mant_f >> shift;
+    mant_t += round_bit;                                        // ARU: no sticky
+
+    int32_t exp_out = exp_t;
+    if (mant_t == (1u << m)) {
+        mant_t  = 0u;
+        exp_out += 1;
+    }
+
+    const int32_t max_exp = (1 << e) - 1;
+    if (exp_out > max_exp) {
+        exp_out = max_exp;
+        mant_t  = (1u << m) - 1u;
+    }
+
+    return uint8_t((sign << 7) | (uint32_t(exp_out) << m) | mant_t);
+}
+
+
+// ----------------------------------------------------------------------------
+// Helper D: decode_fp8. FP8(e, m, b) -> FP32. Inverse of encode_fp8.
+// ----------------------------------------------------------------------------
+__device__ __forceinline__
+float decode_fp8(uint8_t byte, int e, int m, int b) {
+    const uint32_t u     = uint32_t(byte);
+    const uint32_t sign  = (u >> 7) & 1u;
+    const uint32_t exp_t = (u >> m) & ((1u << e) - 1u);
+    const uint32_t mant  = u & ((1u << m) - 1u);
+
+    if (exp_t == 0u) {
+        if (mant == 0u) return sign ? -0.0f : 0.0f;
+        const float v = ldexpf(float(mant), 1 - b - m);
+        return sign ? -v : v;
+    }
+
+    const int32_t  exp_f  = int32_t(exp_t) - b + 127;
+    const uint32_t mant_f = mant << (23 - m);
+    const uint32_t bits   = (sign << 31) | (uint32_t(exp_f) << 23) | mant_f;
+    return __uint_as_float(bits);
+}

--- a/runspace/src/quantization/cuda/fp8_decode.cu
+++ b/runspace/src/quantization/cuda/fp8_decode.cu
@@ -1,0 +1,180 @@
+// runspace/src/quantization/cuda/fp8_decode.cu
+//
+// Phase 0 decode kernels:
+//   decode_fp8_chunk : per-chunk power-of-two scale.
+//   decode_fp8_tensor    : single scalar scale. Accepts any N >= 1 via
+//                          vectorized bulk + scalar tail handler.
+//   decode_fp8_channel   : per-channel scales, K multiple of 4.
+
+#include "fp8_codec.cuh"
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+
+
+// ============================================================================
+// 1. Per-chunk decode.
+// ============================================================================
+
+extern "C" __global__
+void decode_fp8_chunk(
+    const uint8_t* __restrict__ in,
+    const float*   __restrict__ scales,
+    float*         __restrict__ out,
+    int N, int chunk_size,
+    int e, int m, int b)
+{
+    const int chunk_id = blockIdx.x;
+    const int lane     = threadIdx.x;
+    const int base     = chunk_id * chunk_size;
+
+    const float    s      = scales[chunk_id];
+    const uint32_t packed = reinterpret_cast<const uint32_t*>(in + base)[lane];
+
+    float4 v;
+    v.x = decode_fp8(uint8_t( packed        & 0xFFu), e, m, b) * s;
+    v.y = decode_fp8(uint8_t((packed >>  8) & 0xFFu), e, m, b) * s;
+    v.z = decode_fp8(uint8_t((packed >> 16) & 0xFFu), e, m, b) * s;
+    v.w = decode_fp8(uint8_t((packed >> 24) & 0xFFu), e, m, b) * s;
+
+    reinterpret_cast<float4*>(out + base)[lane] = v;
+}
+
+void launch_decode_fp8_chunk(
+    torch::Tensor in, torch::Tensor scales, torch::Tensor out,
+    int e, int m, int b, int chunk_size)
+{
+    TORCH_CHECK(in.is_cuda() && in.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(in.is_contiguous() && scales.is_contiguous() && out.is_contiguous());
+
+    const int N = in.numel();
+    TORCH_CHECK(chunk_size == 128, "R1: chunk_size must be 128");
+    TORCH_CHECK(N % chunk_size == 0);
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scales.numel() == N / chunk_size);
+
+    const dim3 grid(N / chunk_size);
+    const dim3 block(32);
+    decode_fp8_chunk<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        in.data_ptr<uint8_t>(), scales.data_ptr<float>(), out.data_ptr<float>(),
+        N, chunk_size, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 2. Per-tensor decode. Scalar scale, vectorized bulk + scalar tail.
+// ============================================================================
+
+extern "C" __global__
+void decode_fp8_tensor(
+    const uint8_t* __restrict__ in,
+    float*         __restrict__ out,
+    float          s,
+    int            N,
+    int e, int m, int b)
+{
+    const int gid  = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n4   = N >> 2;
+    const int tail = N & 3;
+
+    if (gid < n4) {
+        const uint32_t packed = reinterpret_cast<const uint32_t*>(in)[gid];
+        float4 v;
+        v.x = decode_fp8(uint8_t( packed        & 0xFFu), e, m, b) * s;
+        v.y = decode_fp8(uint8_t((packed >>  8) & 0xFFu), e, m, b) * s;
+        v.z = decode_fp8(uint8_t((packed >> 16) & 0xFFu), e, m, b) * s;
+        v.w = decode_fp8(uint8_t((packed >> 24) & 0xFFu), e, m, b) * s;
+        reinterpret_cast<float4*>(out)[gid] = v;
+        return;
+    }
+
+    if (gid == n4 && tail > 0) {
+        const int base = n4 << 2;
+        if (tail >= 1) out[base + 0] = decode_fp8(in[base + 0], e, m, b) * s;
+        if (tail >= 2) out[base + 1] = decode_fp8(in[base + 1], e, m, b) * s;
+        if (tail >= 3) out[base + 2] = decode_fp8(in[base + 2], e, m, b) * s;
+    }
+}
+
+void launch_decode_fp8_tensor(
+    torch::Tensor in, torch::Tensor out, double scale,
+    int e, int m, int b)
+{
+    TORCH_CHECK(in.is_cuda() && in.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(in.is_contiguous() && out.is_contiguous());
+
+    const int N = in.numel();
+    TORCH_CHECK(out.numel() == N);
+    if (N == 0) return;
+
+    const int n4         = N / 4;
+    const int tail       = N - n4 * 4;
+    const int total_work = n4 + (tail > 0 ? 1 : 0);
+    const int block      = 256;
+    const int grid       = (total_work + block - 1) / block;
+    const float s        = static_cast<float>(scale);
+
+    decode_fp8_tensor<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        in.data_ptr<uint8_t>(), out.data_ptr<float>(),
+        s, N, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 3. Per-channel decode.
+// ============================================================================
+
+extern "C" __global__
+void decode_fp8_channel(
+    const uint8_t* __restrict__ in,
+    const float*   __restrict__ scales,
+    float*         __restrict__ out,
+    int C, int K, int k4,
+    int e, int m, int b)
+{
+    const int channel_id    = blockIdx.y;
+    const int element_in_ch = blockIdx.x * blockDim.x + threadIdx.x;
+    if (element_in_ch >= k4 || channel_id >= C) return;
+
+    const float s    = scales[channel_id];
+    const int   base = channel_id * K;
+
+    const uint32_t packed = reinterpret_cast<const uint32_t*>(in + base)[element_in_ch];
+    float4 v;
+    v.x = decode_fp8(uint8_t( packed        & 0xFFu), e, m, b) * s;
+    v.y = decode_fp8(uint8_t((packed >>  8) & 0xFFu), e, m, b) * s;
+    v.z = decode_fp8(uint8_t((packed >> 16) & 0xFFu), e, m, b) * s;
+    v.w = decode_fp8(uint8_t((packed >> 24) & 0xFFu), e, m, b) * s;
+    reinterpret_cast<float4*>(out + base)[element_in_ch] = v;
+}
+
+void launch_decode_fp8_channel(
+    torch::Tensor in, torch::Tensor scales, torch::Tensor out,
+    int e, int m, int b)
+{
+    TORCH_CHECK(in.is_cuda() && in.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(in.is_contiguous() && scales.is_contiguous() && out.is_contiguous());
+    TORCH_CHECK(out.dim() == 2, "decode_fp8_channel: out must be 2D (C, K)");
+
+    const int C = out.size(0);
+    const int K = out.size(1);
+    TORCH_CHECK(K % 4 == 0);
+    TORCH_CHECK(in.numel() == C * K);
+    TORCH_CHECK(scales.numel() == C);
+
+    const int k4    = K / 4;
+    const int block = 256;
+    const dim3 grid((k4 + block - 1) / block, C);
+
+    decode_fp8_channel<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        in.data_ptr<uint8_t>(), scales.data_ptr<float>(), out.data_ptr<float>(),
+        C, K, k4, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}

--- a/runspace/src/quantization/cuda/fp8_encode.cu
+++ b/runspace/src/quantization/cuda/fp8_encode.cu
@@ -1,0 +1,722 @@
+// runspace/src/quantization/cuda/fp8_encode.cu
+//
+// Phase 0 encode kernels:
+//   encode_fp8_chunk  : per-chunk power-of-two scale, chunk_size = 128.
+//   encode_fp8_tensor     : single scalar scale (host-computed). Accepts any
+//                           N >= 1 via vectorized bulk + scalar tail handler.
+//   encode_fp8_channel    : per-channel scales (host-computed). K must be a
+//                           multiple of 4.
+//
+// All three share the encode_fp8 device function from fp8_codec.cuh.
+
+#include "fp8_codec.cuh"
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+
+
+// Forward declarations: defined in fp8_decode.cu.
+void launch_decode_fp8_chunk(torch::Tensor, torch::Tensor, torch::Tensor,
+                                 int, int, int, int);
+void launch_decode_fp8_tensor   (torch::Tensor, torch::Tensor, double,
+                                 int, int, int);
+void launch_decode_fp8_channel  (torch::Tensor, torch::Tensor, torch::Tensor,
+                                 int, int, int);
+
+
+// ============================================================================
+// 1. Per-chunk encode.
+// ============================================================================
+
+extern "C" __global__
+void encode_fp8_chunk(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float*       __restrict__ scales,
+    int N,
+    int chunk_size,
+    int e, int m, int b)
+{
+    const int chunk_id = blockIdx.x;
+    const int lane     = threadIdx.x;
+    const int base     = chunk_id * chunk_size;
+
+    float4 v = reinterpret_cast<const float4*>(x + base)[lane];
+    const float local_max = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                                  fmaxf(fabsf(v.z), fabsf(v.w)));
+    const float amax  = warp_amax(local_max);
+    const float s     = pow2_floor_nonneg(amax);
+    const float inv_s = 1.0f / s;
+
+    if (lane == 0) scales[chunk_id] = s;
+
+    const uint32_t packed =
+        uint32_t(encode_fp8(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[lane] = packed;
+}
+
+void launch_encode_fp8_chunk(
+    torch::Tensor x, torch::Tensor out, torch::Tensor scales,
+    int e, int m, int b, int chunk_size)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous() && scales.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(chunk_size == 128, "R1: chunk_size must be 128");
+    TORCH_CHECK(N % chunk_size == 0);
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scales.numel() == N / chunk_size);
+
+    const dim3 grid(N / chunk_size);
+    const dim3 block(32);
+    encode_fp8_chunk<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(), scales.data_ptr<float>(),
+        N, chunk_size, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 2. Per-tensor encode. Scalar scale, vectorized bulk + scalar tail.
+//
+//    Layout:
+//      gid in [0, n4)     handles a full quartet via float4 / uint32.
+//      gid == n4 (one thread, only if tail > 0) handles the 1, 2, or 3
+//                         leftover scalar elements.
+// ============================================================================
+
+extern "C" __global__
+void encode_fp8_tensor(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float        inv_s,
+    int          N,
+    int e, int m, int b)
+{
+    const int gid  = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n4   = N >> 2;                  // N / 4
+    const int tail = N & 3;                   // N % 4
+
+    if (gid < n4) {
+        const float4 v = reinterpret_cast<const float4*>(x)[gid];
+        const uint32_t packed =
+            uint32_t(encode_fp8(v.x * inv_s, e, m, b))         |
+            (uint32_t(encode_fp8(v.y * inv_s, e, m, b)) <<  8) |
+            (uint32_t(encode_fp8(v.z * inv_s, e, m, b)) << 16) |
+            (uint32_t(encode_fp8(v.w * inv_s, e, m, b)) << 24);
+        reinterpret_cast<uint32_t*>(out)[gid] = packed;
+        return;
+    }
+
+    if (gid == n4 && tail > 0) {
+        const int base = n4 << 2;             // n4 * 4
+        if (tail >= 1) out[base + 0] = encode_fp8(x[base + 0] * inv_s, e, m, b);
+        if (tail >= 2) out[base + 1] = encode_fp8(x[base + 1] * inv_s, e, m, b);
+        if (tail >= 3) out[base + 2] = encode_fp8(x[base + 2] * inv_s, e, m, b);
+    }
+}
+
+void launch_encode_fp8_tensor(
+    torch::Tensor x, torch::Tensor out, double scale,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scale > 0.0, "encode_fp8_tensor: scale must be positive");
+    if (N == 0) return;                       // nothing to do
+
+    const int n4         = N / 4;
+    const int tail       = N - n4 * 4;
+    const int total_work = n4 + (tail > 0 ? 1 : 0);
+    const int block      = 256;
+    const int grid       = (total_work + block - 1) / block;
+    const float inv_s    = 1.0f / static_cast<float>(scale);
+
+    encode_fp8_tensor<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        inv_s, N, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 3. Per-channel encode. Input layout [C, K], K multiple of 4.
+// ============================================================================
+
+extern "C" __global__
+void encode_fp8_channel(
+    const float* __restrict__ x,
+    const float* __restrict__ scales,
+    uint8_t*     __restrict__ out,
+    int C, int K, int k4,
+    int e, int m, int b)
+{
+    const int channel_id     = blockIdx.y;
+    const int element_in_ch  = blockIdx.x * blockDim.x + threadIdx.x;
+    if (element_in_ch >= k4 || channel_id >= C) return;
+
+    const float inv_s = 1.0f / scales[channel_id];
+    const int   base  = channel_id * K;
+
+    const float4 v = reinterpret_cast<const float4*>(x + base)[element_in_ch];
+    const uint32_t packed =
+        uint32_t(encode_fp8(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[element_in_ch] = packed;
+}
+
+void launch_encode_fp8_channel(
+    torch::Tensor x, torch::Tensor scales, torch::Tensor out,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && scales.is_contiguous() && out.is_contiguous());
+    TORCH_CHECK(x.dim() == 2, "encode_fp8_channel: x must be 2D (C, K)");
+
+    const int C = x.size(0);
+    const int K = x.size(1);
+    TORCH_CHECK(K % 4 == 0, "encode_fp8_channel: K must be multiple of 4");
+    TORCH_CHECK(scales.numel() == C);
+    TORCH_CHECK(out.numel() == C * K);
+
+    const int k4    = K / 4;
+    const int block = 256;
+    const dim3 grid((k4 + block - 1) / block, C);
+
+    encode_fp8_channel<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), scales.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        C, K, k4, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 4. ARU variants (Always Round Up — no sticky bit).
+// ============================================================================
+
+extern "C" __global__
+void encode_fp8_chunk_ARU(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float*       __restrict__ scales,
+    int N,
+    int chunk_size,
+    int e, int m, int b)
+{
+    const int chunk_id = blockIdx.x;
+    const int lane     = threadIdx.x;
+    const int base     = chunk_id * chunk_size;
+
+    float4 v = reinterpret_cast<const float4*>(x + base)[lane];
+    const float local_max = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                                  fmaxf(fabsf(v.z), fabsf(v.w)));
+    const float amax  = warp_amax(local_max);
+    const float s     = pow2_floor_nonneg(amax);
+    const float inv_s = 1.0f / s;
+
+    if (lane == 0) scales[chunk_id] = s;
+
+    const uint32_t packed =
+        uint32_t(encode_fp8_ARU(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8_ARU(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8_ARU(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8_ARU(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[lane] = packed;
+}
+
+void launch_encode_fp8_chunk_ARU(
+    torch::Tensor x, torch::Tensor out, torch::Tensor scales,
+    int e, int m, int b, int chunk_size)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous() && scales.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(chunk_size == 128, "R1: chunk_size must be 128");
+    TORCH_CHECK(N % chunk_size == 0);
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scales.numel() == N / chunk_size);
+
+    const dim3 grid(N / chunk_size);
+    const dim3 block(32);
+    encode_fp8_chunk_ARU<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(), scales.data_ptr<float>(),
+        N, chunk_size, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" __global__
+void encode_fp8_tensor_ARU(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float        inv_s,
+    int          N,
+    int e, int m, int b)
+{
+    const int gid  = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n4   = N >> 2;
+    const int tail = N & 3;
+
+    if (gid < n4) {
+        const float4 v = reinterpret_cast<const float4*>(x)[gid];
+        const uint32_t packed =
+            uint32_t(encode_fp8_ARU(v.x * inv_s, e, m, b))         |
+            (uint32_t(encode_fp8_ARU(v.y * inv_s, e, m, b)) <<  8) |
+            (uint32_t(encode_fp8_ARU(v.z * inv_s, e, m, b)) << 16) |
+            (uint32_t(encode_fp8_ARU(v.w * inv_s, e, m, b)) << 24);
+        reinterpret_cast<uint32_t*>(out)[gid] = packed;
+        return;
+    }
+
+    if (gid == n4 && tail > 0) {
+        const int base = n4 << 2;
+        if (tail >= 1) out[base + 0] = encode_fp8_ARU(x[base + 0] * inv_s, e, m, b);
+        if (tail >= 2) out[base + 1] = encode_fp8_ARU(x[base + 1] * inv_s, e, m, b);
+        if (tail >= 3) out[base + 2] = encode_fp8_ARU(x[base + 2] * inv_s, e, m, b);
+    }
+}
+
+void launch_encode_fp8_tensor_ARU(
+    torch::Tensor x, torch::Tensor out, double scale,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scale > 0.0, "encode_fp8_tensor_ARU: scale must be positive");
+    if (N == 0) return;
+
+    const int n4         = N / 4;
+    const int tail       = N - n4 * 4;
+    const int total_work = n4 + (tail > 0 ? 1 : 0);
+    const int block      = 256;
+    const int grid       = (total_work + block - 1) / block;
+    const float inv_s    = 1.0f / static_cast<float>(scale);
+
+    encode_fp8_tensor_ARU<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        inv_s, N, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" __global__
+void encode_fp8_channel_ARU(
+    const float* __restrict__ x,
+    const float* __restrict__ scales,
+    uint8_t*     __restrict__ out,
+    int C, int K, int k4,
+    int e, int m, int b)
+{
+    const int channel_id     = blockIdx.y;
+    const int element_in_ch  = blockIdx.x * blockDim.x + threadIdx.x;
+    if (element_in_ch >= k4 || channel_id >= C) return;
+
+    const float inv_s = 1.0f / scales[channel_id];
+    const int   base  = channel_id * K;
+
+    const float4 v = reinterpret_cast<const float4*>(x + base)[element_in_ch];
+    const uint32_t packed =
+        uint32_t(encode_fp8_ARU(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8_ARU(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8_ARU(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8_ARU(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[element_in_ch] = packed;
+}
+
+void launch_encode_fp8_channel_ARU(
+    torch::Tensor x, torch::Tensor scales, torch::Tensor out,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && scales.is_contiguous() && out.is_contiguous());
+    TORCH_CHECK(x.dim() == 2, "encode_fp8_channel_ARU: x must be 2D (C, K)");
+
+    const int C = x.size(0);
+    const int K = x.size(1);
+    TORCH_CHECK(K % 4 == 0, "encode_fp8_channel_ARU: K must be multiple of 4");
+    TORCH_CHECK(scales.numel() == C);
+    TORCH_CHECK(out.numel() == C * K);
+
+    const int k4    = K / 4;
+    const int block = 256;
+    const dim3 grid((k4 + block - 1) / block, C);
+
+    encode_fp8_channel_ARU<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), scales.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        C, K, k4, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 5. nf variants (No subnormal Flush — RNTE rounding).
+// ============================================================================
+
+extern "C" __global__
+void encode_fp8_chunk_nf(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float*       __restrict__ scales,
+    int N,
+    int chunk_size,
+    int e, int m, int b)
+{
+    const int chunk_id = blockIdx.x;
+    const int lane     = threadIdx.x;
+    const int base     = chunk_id * chunk_size;
+
+    float4 v = reinterpret_cast<const float4*>(x + base)[lane];
+    const float local_max = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                                  fmaxf(fabsf(v.z), fabsf(v.w)));
+    const float amax  = warp_amax(local_max);
+    const float s     = pow2_floor_nonneg(amax);
+    const float inv_s = 1.0f / s;
+
+    if (lane == 0) scales[chunk_id] = s;
+
+    const uint32_t packed =
+        uint32_t(encode_fp8_nf(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8_nf(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8_nf(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8_nf(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[lane] = packed;
+}
+
+void launch_encode_fp8_chunk_nf(
+    torch::Tensor x, torch::Tensor out, torch::Tensor scales,
+    int e, int m, int b, int chunk_size)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous() && scales.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(chunk_size == 128, "R1: chunk_size must be 128");
+    TORCH_CHECK(N % chunk_size == 0);
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scales.numel() == N / chunk_size);
+
+    const dim3 grid(N / chunk_size);
+    const dim3 block(32);
+    encode_fp8_chunk_nf<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(), scales.data_ptr<float>(),
+        N, chunk_size, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" __global__
+void encode_fp8_tensor_nf(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float        inv_s,
+    int          N,
+    int e, int m, int b)
+{
+    const int gid  = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n4   = N >> 2;
+    const int tail = N & 3;
+
+    if (gid < n4) {
+        const float4 v = reinterpret_cast<const float4*>(x)[gid];
+        const uint32_t packed =
+            uint32_t(encode_fp8_nf(v.x * inv_s, e, m, b))         |
+            (uint32_t(encode_fp8_nf(v.y * inv_s, e, m, b)) <<  8) |
+            (uint32_t(encode_fp8_nf(v.z * inv_s, e, m, b)) << 16) |
+            (uint32_t(encode_fp8_nf(v.w * inv_s, e, m, b)) << 24);
+        reinterpret_cast<uint32_t*>(out)[gid] = packed;
+        return;
+    }
+
+    if (gid == n4 && tail > 0) {
+        const int base = n4 << 2;
+        if (tail >= 1) out[base + 0] = encode_fp8_nf(x[base + 0] * inv_s, e, m, b);
+        if (tail >= 2) out[base + 1] = encode_fp8_nf(x[base + 1] * inv_s, e, m, b);
+        if (tail >= 3) out[base + 2] = encode_fp8_nf(x[base + 2] * inv_s, e, m, b);
+    }
+}
+
+void launch_encode_fp8_tensor_nf(
+    torch::Tensor x, torch::Tensor out, double scale,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scale > 0.0, "encode_fp8_tensor_nf: scale must be positive");
+    if (N == 0) return;
+
+    const int n4         = N / 4;
+    const int tail       = N - n4 * 4;
+    const int total_work = n4 + (tail > 0 ? 1 : 0);
+    const int block      = 256;
+    const int grid       = (total_work + block - 1) / block;
+    const float inv_s    = 1.0f / static_cast<float>(scale);
+
+    encode_fp8_tensor_nf<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        inv_s, N, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" __global__
+void encode_fp8_channel_nf(
+    const float* __restrict__ x,
+    const float* __restrict__ scales,
+    uint8_t*     __restrict__ out,
+    int C, int K, int k4,
+    int e, int m, int b)
+{
+    const int channel_id     = blockIdx.y;
+    const int element_in_ch  = blockIdx.x * blockDim.x + threadIdx.x;
+    if (element_in_ch >= k4 || channel_id >= C) return;
+
+    const float inv_s = 1.0f / scales[channel_id];
+    const int   base  = channel_id * K;
+
+    const float4 v = reinterpret_cast<const float4*>(x + base)[element_in_ch];
+    const uint32_t packed =
+        uint32_t(encode_fp8_nf(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8_nf(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8_nf(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8_nf(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[element_in_ch] = packed;
+}
+
+void launch_encode_fp8_channel_nf(
+    torch::Tensor x, torch::Tensor scales, torch::Tensor out,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && scales.is_contiguous() && out.is_contiguous());
+    TORCH_CHECK(x.dim() == 2, "encode_fp8_channel_nf: x must be 2D (C, K)");
+
+    const int C = x.size(0);
+    const int K = x.size(1);
+    TORCH_CHECK(K % 4 == 0, "encode_fp8_channel_nf: K must be multiple of 4");
+    TORCH_CHECK(scales.numel() == C);
+    TORCH_CHECK(out.numel() == C * K);
+
+    const int k4    = K / 4;
+    const int block = 256;
+    const dim3 grid((k4 + block - 1) / block, C);
+
+    encode_fp8_channel_nf<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), scales.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        C, K, k4, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// 6. ARU_nf variants (Always Round Up + No subnormal Flush).
+// ============================================================================
+
+extern "C" __global__
+void encode_fp8_chunk_ARU_nf(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float*       __restrict__ scales,
+    int N,
+    int chunk_size,
+    int e, int m, int b)
+{
+    const int chunk_id = blockIdx.x;
+    const int lane     = threadIdx.x;
+    const int base     = chunk_id * chunk_size;
+
+    float4 v = reinterpret_cast<const float4*>(x + base)[lane];
+    const float local_max = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                                  fmaxf(fabsf(v.z), fabsf(v.w)));
+    const float amax  = warp_amax(local_max);
+    const float s     = pow2_floor_nonneg(amax);
+    const float inv_s = 1.0f / s;
+
+    if (lane == 0) scales[chunk_id] = s;
+
+    const uint32_t packed =
+        uint32_t(encode_fp8_ARU_nf(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8_ARU_nf(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8_ARU_nf(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8_ARU_nf(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[lane] = packed;
+}
+
+void launch_encode_fp8_chunk_ARU_nf(
+    torch::Tensor x, torch::Tensor out, torch::Tensor scales,
+    int e, int m, int b, int chunk_size)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous() && scales.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(chunk_size == 128, "R1: chunk_size must be 128");
+    TORCH_CHECK(N % chunk_size == 0);
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scales.numel() == N / chunk_size);
+
+    const dim3 grid(N / chunk_size);
+    const dim3 block(32);
+    encode_fp8_chunk_ARU_nf<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(), scales.data_ptr<float>(),
+        N, chunk_size, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" __global__
+void encode_fp8_tensor_ARU_nf(
+    const float* __restrict__ x,
+    uint8_t*     __restrict__ out,
+    float        inv_s,
+    int          N,
+    int e, int m, int b)
+{
+    const int gid  = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n4   = N >> 2;
+    const int tail = N & 3;
+
+    if (gid < n4) {
+        const float4 v = reinterpret_cast<const float4*>(x)[gid];
+        const uint32_t packed =
+            uint32_t(encode_fp8_ARU_nf(v.x * inv_s, e, m, b))         |
+            (uint32_t(encode_fp8_ARU_nf(v.y * inv_s, e, m, b)) <<  8) |
+            (uint32_t(encode_fp8_ARU_nf(v.z * inv_s, e, m, b)) << 16) |
+            (uint32_t(encode_fp8_ARU_nf(v.w * inv_s, e, m, b)) << 24);
+        reinterpret_cast<uint32_t*>(out)[gid] = packed;
+        return;
+    }
+
+    if (gid == n4 && tail > 0) {
+        const int base = n4 << 2;
+        if (tail >= 1) out[base + 0] = encode_fp8_ARU_nf(x[base + 0] * inv_s, e, m, b);
+        if (tail >= 2) out[base + 1] = encode_fp8_ARU_nf(x[base + 1] * inv_s, e, m, b);
+        if (tail >= 3) out[base + 2] = encode_fp8_ARU_nf(x[base + 2] * inv_s, e, m, b);
+    }
+}
+
+void launch_encode_fp8_tensor_ARU_nf(
+    torch::Tensor x, torch::Tensor out, double scale,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && out.is_contiguous());
+
+    const int N = x.numel();
+    TORCH_CHECK(out.numel() == N);
+    TORCH_CHECK(scale > 0.0, "encode_fp8_tensor_ARU_nf: scale must be positive");
+    if (N == 0) return;
+
+    const int n4         = N / 4;
+    const int tail       = N - n4 * 4;
+    const int total_work = n4 + (tail > 0 ? 1 : 0);
+    const int block      = 256;
+    const int grid       = (total_work + block - 1) / block;
+    const float inv_s    = 1.0f / static_cast<float>(scale);
+
+    encode_fp8_tensor_ARU_nf<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        inv_s, N, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" __global__
+void encode_fp8_channel_ARU_nf(
+    const float* __restrict__ x,
+    const float* __restrict__ scales,
+    uint8_t*     __restrict__ out,
+    int C, int K, int k4,
+    int e, int m, int b)
+{
+    const int channel_id     = blockIdx.y;
+    const int element_in_ch  = blockIdx.x * blockDim.x + threadIdx.x;
+    if (element_in_ch >= k4 || channel_id >= C) return;
+
+    const float inv_s = 1.0f / scales[channel_id];
+    const int   base  = channel_id * K;
+
+    const float4 v = reinterpret_cast<const float4*>(x + base)[element_in_ch];
+    const uint32_t packed =
+        uint32_t(encode_fp8_ARU_nf(v.x * inv_s, e, m, b))         |
+        (uint32_t(encode_fp8_ARU_nf(v.y * inv_s, e, m, b)) <<  8) |
+        (uint32_t(encode_fp8_ARU_nf(v.z * inv_s, e, m, b)) << 16) |
+        (uint32_t(encode_fp8_ARU_nf(v.w * inv_s, e, m, b)) << 24);
+    reinterpret_cast<uint32_t*>(out + base)[element_in_ch] = packed;
+}
+
+void launch_encode_fp8_channel_ARU_nf(
+    torch::Tensor x, torch::Tensor scales, torch::Tensor out,
+    int e, int m, int b)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(scales.is_cuda() && scales.scalar_type() == torch::kFloat32);
+    TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kUInt8);
+    TORCH_CHECK(x.is_contiguous() && scales.is_contiguous() && out.is_contiguous());
+    TORCH_CHECK(x.dim() == 2, "encode_fp8_channel_ARU_nf: x must be 2D (C, K)");
+
+    const int C = x.size(0);
+    const int K = x.size(1);
+    TORCH_CHECK(K % 4 == 0, "encode_fp8_channel_ARU_nf: K must be multiple of 4");
+    TORCH_CHECK(scales.numel() == C);
+    TORCH_CHECK(out.numel() == C * K);
+
+    const int k4    = K / 4;
+    const int block = 256;
+    const dim3 grid((k4 + block - 1) / block, C);
+
+    encode_fp8_channel_ARU_nf<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+        x.data_ptr<float>(), scales.data_ptr<float>(), out.data_ptr<uint8_t>(),
+        C, K, k4, e, m, b);
+    AT_CUDA_CHECK(cudaGetLastError());
+}
+
+
+// ============================================================================
+// PYBIND
+// ============================================================================
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, mod) {
+    mod.def("encode_fp8_chunk",          &launch_encode_fp8_chunk);
+    mod.def("decode_fp8_chunk",          &launch_decode_fp8_chunk);
+    mod.def("encode_fp8_tensor",         &launch_encode_fp8_tensor);
+    mod.def("decode_fp8_tensor",         &launch_decode_fp8_tensor);
+    mod.def("encode_fp8_channel",        &launch_encode_fp8_channel);
+    mod.def("decode_fp8_channel",        &launch_decode_fp8_channel);
+    mod.def("encode_fp8_chunk_ARU",      &launch_encode_fp8_chunk_ARU);
+    mod.def("encode_fp8_tensor_ARU",     &launch_encode_fp8_tensor_ARU);
+    mod.def("encode_fp8_channel_ARU",    &launch_encode_fp8_channel_ARU);
+    mod.def("encode_fp8_chunk_nf",       &launch_encode_fp8_chunk_nf);
+    mod.def("encode_fp8_tensor_nf",      &launch_encode_fp8_tensor_nf);
+    mod.def("encode_fp8_channel_nf",     &launch_encode_fp8_channel_nf);
+    mod.def("encode_fp8_chunk_ARU_nf",   &launch_encode_fp8_chunk_ARU_nf);
+    mod.def("encode_fp8_tensor_ARU_nf",  &launch_encode_fp8_tensor_ARU_nf);
+    mod.def("encode_fp8_channel_ARU_nf", &launch_encode_fp8_channel_ARU_nf);
+}


### PR DESCRIPTION
- Implemented per-chunk, per-tensor, and per-channel FP8 encoding and decoding kernels in CUDA.
- Added support for both standard and ARU (Always Round Up) variants for encoding.
- Included handling for cases with no subnormal flush and RNTE rounding.
- Introduced new functions for launching these kernels from PyTorch.
- Ensured proper checks for tensor types and dimensions in the launch functions.